### PR TITLE
chore: document Expo setup and add tooling

### DIFF
--- a/drop_natively/.eslintrc.cjs
+++ b/drop_natively/.eslintrc.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  root: true,
+  extends: ['expo', 'plugin:@typescript-eslint/recommended'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  env: {
+    node: true,
+  },
+  rules: {},
+};

--- a/drop_natively/README.md
+++ b/drop_natively/README.md
@@ -1,0 +1,53 @@
+# Drop Natively
+
+This Expo project mirrors the Drop presence logging experience on mobile. The tasks in `SPRINTS.md` assume the following local setup.
+
+## Prerequisites
+
+- Node.js 20 (LTS) and npm
+- Expo CLI (`npm install --global expo`)
+- Android Studio / Xcode simulators for native testing (optional but recommended)
+
+## Installation
+
+```bash
+npm install
+```
+
+## Available scripts
+
+| Script | Description |
+| --- | --- |
+| `npm run start` | Start the Expo development server in Metro web UI. |
+| `npm run android` | Launch Expo in an Android emulator or connected device. |
+| `npm run ios` | Launch Expo in an iOS simulator (macOS only). |
+| `npm run web` | Run the project in a web browser. |
+| `npm test` | Execute the Node.js test runner across `__tests__` files. |
+| `npm run lint` | Run ESLint against the project. |
+
+Each native command forwards to `expo start` with the appropriate platform flag. If you need to start without the Metro UI, append `--non-interactive`:
+
+```bash
+npm run start -- --non-interactive
+```
+
+## Testing and linting
+
+```bash
+npm test
+npm run lint
+```
+
+Tests currently use Node's built-in test runner so that they work in offline environments. A minimal `jest.config.js` is provided for future parity with the web project once Jest can be installed.
+
+## Running on device
+
+1. Start the Metro server: `npm run start`.
+2. Install the [Expo Go](https://expo.dev/client) app on your device or open an emulator.
+3. Scan the QR code from the Metro web UI (or use the platform-specific script above).
+
+## Troubleshooting
+
+- **Port already in use** – add `--port <number>` when running `npm run start`.
+- **Cache issues** – run `npm run start -- --clear` to reset Metro.
+- **Stuck builds** – ensure Expo CLI is up to date (`npx expo upgrade` checks the current SDK version).

--- a/drop_natively/__tests__/smoke.test.js
+++ b/drop_natively/__tests__/smoke.test.js
@@ -1,0 +1,6 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+test('project setup is ready for tests', () => {
+  assert.strictEqual(true, true);
+});

--- a/drop_natively/jest.config.js
+++ b/drop_natively/jest.config.js
@@ -1,0 +1,7 @@
+const path = require('path');
+
+module.exports = {
+  rootDir: __dirname,
+  testMatch: ['**/__tests__/**/*.test.js'],
+  setupFilesAfterEnv: [path.join(__dirname, 'jest.setup.js')],
+};

--- a/drop_natively/jest.setup.js
+++ b/drop_natively/jest.setup.js
@@ -1,0 +1,1 @@
+// Minimal Jest setup placeholder for custom matchers.

--- a/drop_natively/package.json
+++ b/drop_natively/package.json
@@ -9,7 +9,9 @@
     "web": "EXPO_NO_TELEMETRY=1 expo start --web",
     "build:web": "expo export -p web && npx workbox generateSW workbox-config.js",
     "build:android": "expo prebuild -p android",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "start": "EXPO_NO_TELEMETRY=1 expo start",
+    "test": "node --test"
   },
   "dependencies": {
     "@babel/plugin-proposal-export-namespace-from": "^7.18.9",


### PR DESCRIPTION
## Summary
- add a README with setup, scripts, and troubleshooting notes for the Expo app
- add npm start/test scripts and configure ESLint plus placeholder Jest settings
- add a Node test-runner smoke test to verify the tooling works

## Testing
- npm test
- npm run start -- --help

------
https://chatgpt.com/codex/tasks/task_e_68cde756528483238a546ddba67811d7