### PR TITLE
Add PWA manifest and service worker

### DIFF
--- a/PWA/manifest.json
+++ b/PWA/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "Drop - Discipline Dashboard",
+  "short_name": "Drop",
+  "description": "Track daily habits across four life domains",
+  "start_url": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "theme_color": "#000000",
+  "background_color": "#000000",
+  "icons": [
+    {
+      "src": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 192 192'><rect width='192' height='192' fill='%23000'/><text x='96' y='120' text-anchor='middle' font-size='80' font-weight='bold' fill='%23fff'>D</text></svg>",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    }
+  ],
+  "categories": ["productivity", "lifestyle"],
+  "lang": "en"
+}

--- a/PWA/sw.js
+++ b/PWA/sw.js
@@ -1,0 +1,55 @@
+const CACHE_NAME = 'drop-v1';
+const CACHE_FILES = [
+  '/',
+  '/index.html',
+  '/app.js',
+  '/styles.css',
+  '/manifest.json'
+];
+
+// Install service worker
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then((cache) => {
+        return cache.addAll(CACHE_FILES);
+      })
+      .then(() => {
+        return self.skipWaiting();
+      })
+  );
+});
+
+// Activate service worker
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames.map((cacheName) => {
+          if (cacheName !== CACHE_NAME) {
+            return caches.delete(cacheName);
+          }
+        })
+      );
+    }).then(() => {
+      return self.clients.claim();
+    })
+  );
+});
+
+// Fetch strategy
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request)
+      .then((response) => {
+        // Return cached version or fetch from network
+        return response || fetch(event.request);
+      })
+      .catch(() => {
+        // Offline fallback
+        if (event.request.destination === 'document') {
+          return caches.match('/index.html');
+        }
+      })
+  );
+});


### PR DESCRIPTION
## Summary
- add a PWA manifest describing the Drop application metadata, icon, and display configuration
- create a service worker that precaches core assets and provides an offline fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4b6ec40c48323b8608cb7d72496a6