### PR TITLE
Use existing icons for docs PWA

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
       overlays: document.querySelectorAll('.overlay'),
       navButtons: document.querySelectorAll('.nav-btn'),
       loadingOverlay: document.getElementById('loading-overlay'),
+      installButton: document.getElementById('install-button'),
       devPill: document.getElementById('dev-pill'),
       devToast: document.getElementById('dev-toast'),
       scoreDisplays: {
@@ -65,6 +66,18 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!el) return;
       if (show) el.classList.remove('hidden');
       else el.classList.add('hidden');
+    },
+
+    showInstallButton(show = true) {
+      const btn = this.elements.installButton;
+      if (!btn) return;
+      if (show) {
+        btn.removeAttribute('hidden');
+        btn.disabled = false;
+      } else {
+        btn.setAttribute('hidden', '');
+        btn.disabled = false;
+      }
     },
 
     toast(msg, ms = 1500) {
@@ -130,6 +143,8 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const App = {
+    deferredInstallPrompt: null,
+
     init() {
       Store.init();
       UI.initDate();
@@ -139,6 +154,7 @@ document.addEventListener('DOMContentLoaded', () => {
       this.updateScores();
       this.bindEvents();
       this.registerServiceWorker();
+      this.initInstallPrompt();
 
       // Hide loading overlay when the breath animation finishes (or fallback after animDurationMs)
       const logo = document.querySelector('.loading-logo');
@@ -176,6 +192,58 @@ document.addEventListener('DOMContentLoaded', () => {
         spirit: this.calcSpirit()
       };
       UI.renderScores(scores);
+    },
+
+    initInstallPrompt() {
+      const installBtn = UI.elements.installButton;
+      if (!installBtn) return;
+
+      UI.showInstallButton(false);
+
+      const isStandalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone;
+      if (isStandalone) {
+        return;
+      }
+
+      window.addEventListener('beforeinstallprompt', (event) => {
+        event.preventDefault();
+        this.deferredInstallPrompt = event;
+        UI.showInstallButton(true);
+      });
+
+      window.addEventListener('appinstalled', () => {
+        this.deferredInstallPrompt = null;
+        UI.showInstallButton(false);
+        UI.toast('Life Tracker installed');
+      });
+
+      installBtn.addEventListener('click', async () => {
+        const promptEvent = this.deferredInstallPrompt;
+        if (!promptEvent) {
+          UI.showInstallButton(false);
+          return;
+        }
+
+        installBtn.disabled = true;
+        promptEvent.prompt();
+
+        try {
+          const { outcome } = await promptEvent.userChoice;
+          if (outcome === 'accepted') {
+            UI.toast('Installation started');
+            UI.showInstallButton(false);
+          } else {
+            installBtn.disabled = false;
+            UI.showInstallButton(true);
+          }
+        } catch (error) {
+          console.error('Install prompt failed:', error);
+          installBtn.disabled = false;
+          UI.showInstallButton(true);
+        }
+
+        this.deferredInstallPrompt = null;
+      });
     },
 
     bindEvents() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="theme-color" content="#1C1C21">
+  <meta name="application-name" content="Life Tracker">
+  <meta name="apple-mobile-web-app-title" content="Life Tracker">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&family=Wix+Madefor+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="icon" type="image/png" href="icons/drop_rounded.png">
   <link rel="manifest" href="manifest.json">
+  <link rel="apple-touch-icon" href="icons/drop_rounded.png">
   <link rel="stylesheet" href="styles.css">
   <title>Life Tracker</title>
 </head>
@@ -29,7 +33,13 @@
   <div class="dev-toast" id="dev-toast" aria-live="polite"></div>
 
   <header class="app-header">
-    <div class="date" id="date-display"></div>
+    <div class="app-header__top">
+      <div class="date" id="date-display"></div>
+      <button class="install-button" id="install-button" aria-label="Install Life Tracker" hidden>
+        <span class="install-button__icon" aria-hidden="true">➕</span>
+        <span>Install App</span>
+      </button>
+    </div>
     <div class="scores-grid">
       <div class="score-item">
         <div class="score-circle">

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2,23 +2,28 @@
   "name": "Life Tracker",
   "short_name": "LifeTrack",
   "description": "Track your sleep, fitness, mind, and spirit daily.",
-  "start_url": ".",
+  "start_url": "./?source=pwa",
+  "scope": "./",
   "display": "standalone",
   "orientation": "portrait",
   "background_color": "#0B0B0F",
   "theme_color": "#1C1C21",
   "icons": [
     {
-      "src": "icons/drop_icon.svg",
-      "sizes": "any",
-      "type": "image/svg+xml",
+      "src": "icons/drop_app_icon.png",
+      "sizes": "1024x1024",
+      "type": "image/png",
       "purpose": "any maskable"
-    }
-    ,
+    },
     {
       "src": "icons/drop_rounded.png",
-      "sizes": "512x512",
+      "sizes": "563x564",
       "type": "image/png"
+    },
+    {
+      "src": "icons/drop_icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
     }
   ]
 }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -68,7 +68,47 @@ body {
 .app-main { flex: 1; display: flex; align-items: center; justify-content: center; padding: 24px; background: radial-gradient(circle at top, var(--color-bg-gradient-start) 0%, var(--color-bg-gradient-end) 100%); }
 
 /* === HEADER === */
-.date { font-size: 14px; color: var(--color-text-secondary); margin-bottom: 16px; font-weight: 500; }
+.app-header__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.date { font-size: 14px; color: var(--color-text-secondary); font-weight: 500; }
+
+.install-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(0, 177, 231, 0.25), rgba(22, 163, 74, 0.25));
+  color: var(--color-text-primary);
+  border: 1px solid rgba(0, 177, 231, 0.35);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.install-button[hidden] { display: none; }
+
+.install-button:focus-visible {
+  outline: 2px solid rgba(0, 177, 231, 0.7);
+  outline-offset: 2px;
+}
+
+.install-button:hover {
+  transform: translateY(-1px);
+  background: linear-gradient(135deg, rgba(0, 177, 231, 0.35), rgba(22, 163, 74, 0.35));
+}
+
+.install-button__icon {
+  font-size: 16px;
+}
 .scores-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; padding: 0 8px; }
 .score-item { 
   text-align: center; 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,13 +1,17 @@
 // Service Worker for Life Tracker PWA
 
-const CACHE_NAME = 'life-tracker-cache-v2'; // Incremented version
+const CACHE_NAME = 'life-tracker-cache-v3';
 const urlsToCache = [
   './',
   './index.html',
   './styles.css',
   './app.js',
   './manifest.json',
+  './icons/drop_app_icon.png',
+  './icons/drop_rounded.png',
   './icons/drop_icon.svg',
+  './icons/vision.svg',
+  './icons/gratitude.svg',
   './icons/fitness.svg',
   './icons/mind.svg',
   './icons/sleep.svg',
@@ -22,21 +26,46 @@ self.addEventListener('install', event => {
         console.log('Opened cache');
         return cache.addAll(urlsToCache);
       })
+      .then(() => self.skipWaiting())
   );
 });
 
 // Fetch event: Serve from cache first, with a network fallback.
-// This makes the app load instantly and work offline.
 self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request)
+        .then(response => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, copy));
+          return response;
+        })
+        .catch(() => caches.match('./index.html'))
+    );
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request)
       .then(response => {
-        // Cache hit - return response
         if (response) {
           return response;
         }
-        // Not in cache - fetch from network
-        return fetch(event.request);
+
+        return fetch(event.request)
+          .then(networkResponse => {
+            if (!networkResponse || networkResponse.status !== 200 || networkResponse.type === 'opaque') {
+              return networkResponse;
+            }
+
+            const responseClone = networkResponse.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(event.request, responseClone));
+            return networkResponse;
+          });
       })
   );
 });
@@ -53,7 +82,7 @@ self.addEventListener('activate', event => {
             return caches.delete(cacheName);
           }
         })
-      );
+      ).then(() => self.clients.claim());
     })
   );
 });


### PR DESCRIPTION
## Summary
- point the docs manifest and apple touch icon to the existing Drop assets so the PWA install flow uses the provided artwork
- refresh the service worker cache list and remove the unused maskable icon files to align with the feedback

## Testing
- python -m json.tool docs/manifest.json

------
https://chatgpt.com/codex/tasks/task_e_68def385183c83239fbb18ce541c5258