### PR TITLE
Ensure navigation visible on Pixel viewport

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -49,10 +49,12 @@ body {
   width: 100%;
   max-width: 412px;
   margin: 0 auto;
-  height: 100vh;
+  min-height: 100dvh;
+  height: auto;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
 }
 
 /* === LAYOUT COMPONENTS === */
@@ -63,9 +65,25 @@ body {
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   z-index: 10;
+  flex-shrink: 0;
 }
-.app-footer { border-bottom: none; border-top: 1px solid var(--color-border); padding: 8px; }
-.app-main { flex: 1; display: flex; align-items: center; justify-content: center; padding: 24px; background: radial-gradient(circle at top, var(--color-bg-gradient-start) 0%, var(--color-bg-gradient-end) 100%); }
+.app-footer {
+  border-bottom: none;
+  border-top: 1px solid var(--color-border);
+  padding: 8px;
+  padding-bottom: calc(8px + env(safe-area-inset-bottom));
+}
+.app-main {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: radial-gradient(circle at top, var(--color-bg-gradient-start) 0%, var(--color-bg-gradient-end) 100%);
+  overflow-y: auto;
+  width: 100%;
+  -webkit-overflow-scrolling: touch;
+}
 
 /* === HEADER === */
 .app-header__top {


### PR DESCRIPTION
## Summary
- adapt the layout shell to use the Pixel 8 viewport height and include safe-area padding
- prevent the footer navigation from shrinking and allow the main content to scroll so the nav stays visible

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68def67bf2c08323a0fb937e5554879f