### PR TITLE
Update PWA branding and improve safe-area layout

### DIFF
--- a/V3.1/index.html
+++ b/V3.1/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" type="image/png" href="icons/drop_rounded.png">
   <link rel="manifest" href="manifest.json">
   <link rel="stylesheet" href="styles.css">
-  <title>Life Tracker</title>
+  <title>drop</title>
 </head>
 <body>
   <!-- Loading overlay shown on app startup (short minimum duration) -->

--- a/V3.1/manifest.json
+++ b/V3.1/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Life Tracker",
-  "short_name": "LifeTrack",
+  "name": "drop",
+  "short_name": "drop",
   "description": "Track your sleep, fitness, mind, and spirit daily.",
   "start_url": ".",
   "display": "standalone",

--- a/V3.1/styles.css
+++ b/V3.1/styles.css
@@ -49,10 +49,12 @@ body {
   width: 100%;
   max-width: 412px;
   margin: 0 auto;
-  height: 100vh;
+  min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 /* === LAYOUT COMPONENTS === */
@@ -64,7 +66,8 @@ body {
   -webkit-backdrop-filter: blur(12px);
   z-index: 10;
 }
-.app-footer { border-bottom: none; border-top: 1px solid var(--color-border); padding: 8px; }
+.app-header { padding-top: calc(16px + env(safe-area-inset-top)); }
+.app-footer { border-bottom: none; border-top: 1px solid var(--color-border); padding: 8px; padding-bottom: calc(8px + env(safe-area-inset-bottom)); }
 .app-main { flex: 1; display: flex; align-items: center; justify-content: center; padding: 24px; background: radial-gradient(circle at top, var(--color-bg-gradient-start) 0%, var(--color-bg-gradient-end) 100%); }
 
 /* === HEADER === */


### PR DESCRIPTION
## Summary
- rename the PWA manifest and document title to "drop" so the install prompt uses the new branding
- adjust the layout to rely on dynamic viewport height and safe-area insets so the bottom navigation remains visible

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68def99949dc8323b99126c627b78457