### PR TITLE
Fix PWA metadata to use drop branding

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -214,7 +214,7 @@ document.addEventListener('DOMContentLoaded', () => {
       window.addEventListener('appinstalled', () => {
         this.deferredInstallPrompt = null;
         UI.showInstallButton(false);
-        UI.toast('Life Tracker installed');
+        UI.toast('drop installed');
       });
 
       installBtn.addEventListener('click', async () => {

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,8 +6,8 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="theme-color" content="#1C1C21">
-  <meta name="application-name" content="Life Tracker">
-  <meta name="apple-mobile-web-app-title" content="Life Tracker">
+  <meta name="application-name" content="drop">
+  <meta name="apple-mobile-web-app-title" content="drop">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&family=Wix+Madefor+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
   <link rel="manifest" href="manifest.json">
   <link rel="apple-touch-icon" href="icons/drop_rounded.png">
   <link rel="stylesheet" href="styles.css">
-  <title>Life Tracker</title>
+  <title>drop</title>
 </head>
 <body>
   <!-- Loading overlay shown on app startup (short minimum duration) -->
@@ -35,7 +35,7 @@
   <header class="app-header">
     <div class="app-header__top">
       <div class="date" id="date-display"></div>
-      <button class="install-button" id="install-button" aria-label="Install Life Tracker" hidden>
+      <button class="install-button" id="install-button" aria-label="Install drop" hidden>
         <span class="install-button__icon" aria-hidden="true">➕</span>
         <span>Install App</span>
       </button>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Life Tracker",
-  "short_name": "LifeTrack",
+  "name": "drop",
+  "short_name": "drop",
   "description": "Track your sleep, fitness, mind, and spirit daily.",
   "start_url": "./?source=pwa",
   "scope": "./",

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,4 +1,4 @@
-// Service Worker for Life Tracker PWA
+// Service Worker for drop PWA
 
 const CACHE_NAME = 'life-tracker-cache-v3';
 const urlsToCache = [


### PR DESCRIPTION
## Summary
- update the public PWA metadata to use the drop product name instead of Life Tracker
- adjust the install toast message to reflect the new branding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68defbe43b088323a01c4ba1e16bc29a