### PR TITLE
Update service worker cache name for drop PWA

### DIFF
--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for drop PWA
 
-const CACHE_NAME = 'life-tracker-cache-v3';
+const CACHE_NAME = 'drop-cache-v1';
 const urlsToCache = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- update the service worker cache name to drop-cache-v1 so new installs pick up the updated branding

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df3e5491248323a25b4281885e3d05