### PR TITLE
Add structured Vision and Gratitude pages

### DIFF
--- a/V3.1/app.js
+++ b/V3.1/app.js
@@ -34,6 +34,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const UI = {
     elements: {
       dateDisplay: document.getElementById('date-display'),
+      appMain: document.querySelector('.app-main'),
+      pages: document.querySelectorAll('.page'),
       cards: document.querySelectorAll('.card'),
       overlays: document.querySelectorAll('.overlay'),
       navButtons: document.querySelectorAll('.nav-btn'),
@@ -50,7 +52,8 @@ document.addEventListener('DOMContentLoaded', () => {
         wakeTime: document.getElementById('wake-time'),
         restTime: document.getElementById('rest-time'),
         runValue: document.getElementById('run-value'),
-      }
+      },
+      gratitudeDate: document.getElementById('gratitude-date')
     },
 
     renderScores(scores) {
@@ -123,9 +126,55 @@ document.addEventListener('DOMContentLoaded', () => {
     },
 
     initDate() {
-      this.elements.dateDisplay.textContent = new Date().toLocaleDateString('en-US', {
+      const now = new Date();
+      this.elements.dateDisplay.textContent = now.toLocaleDateString('en-US', {
         weekday: 'long', month: 'long', day: 'numeric'
       });
+      this.updateGratitudeDate(now);
+    },
+
+    updateGratitudeDate(date = new Date()) {
+      const el = this.elements.gratitudeDate;
+      if (!el) return;
+      const startOfYear = new Date(date.getFullYear(), 0, 0);
+      const diff = date - startOfYear;
+      const day = Math.floor(diff / (1000 * 60 * 60 * 24));
+      const formatted = date.toLocaleDateString('en-US', { month: 'long', day: 'numeric' });
+      el.textContent = `${formatted} • Day ${day}`;
+    },
+
+    showPage(target) {
+      const { pages, navButtons, appMain } = this.elements;
+      pages.forEach(page => {
+        const isTarget = page.dataset.page === target;
+        page.hidden = !isTarget;
+        if (isTarget) {
+          page.removeAttribute('aria-hidden');
+        } else {
+          page.setAttribute('aria-hidden', 'true');
+        }
+      });
+
+      navButtons.forEach(btn => {
+        const isActive = btn.dataset.target === target;
+        btn.classList.toggle('active', isActive);
+        btn.setAttribute('aria-selected', isActive.toString());
+        if (isActive) {
+          btn.setAttribute('aria-current', 'page');
+        } else {
+          btn.removeAttribute('aria-current');
+        }
+      });
+
+      if (target === 'gratitude') {
+        this.updateGratitudeDate();
+      }
+
+      if (appMain) {
+        appMain.scrollTo({ top: 0, behavior: 'smooth' });
+      } else {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }
     }
   };
 
@@ -139,6 +188,7 @@ document.addEventListener('DOMContentLoaded', () => {
       this.updateScores();
       this.bindEvents();
       this.registerServiceWorker();
+      UI.showPage('home');
 
       // Hide loading overlay when the breath animation finishes (or fallback after animDurationMs)
       const logo = document.querySelector('.loading-logo');
@@ -231,17 +281,8 @@ document.addEventListener('DOMContentLoaded', () => {
       // Nav buttons
       UI.elements.navButtons.forEach(btn => {
         btn.addEventListener('click', () => {
-          const label = btn.querySelector('.nav-label').textContent;
-          if (label === 'Vision') {
-            alert('Vision page - Coming soon!');
-          } else if (label === 'Gratitude') {
-            alert('Gratitude page - Coming soon!');
-          } else if (label === 'Home') {
-            window.scrollTo({ top: 0, behavior: 'smooth' });
-          }
-          // Update active state
-          UI.elements.navButtons.forEach(b => b.classList.remove('active'));
-          btn.classList.add('active');
+          const target = btn.dataset.target || 'home';
+          UI.showPage(target);
         });
       });
     },

--- a/V3.1/index.html
+++ b/V3.1/index.html
@@ -59,41 +59,250 @@
   </header>
 
   <main class="app-main">
-    <div class="main-grid">
-      <div class="card" data-domain="sleep">
-        <img src="icons/sleep.svg" class="card-icon" alt="Sleep">
-        <div class="card-title">Sleep</div>
-        <div class="card-score" id="sleep-card">0</div>
+    <section class="page page--home" id="home-page" data-page="home" aria-label="Daily scores overview">
+      <div class="main-grid">
+        <div class="card" data-domain="sleep">
+          <img src="icons/sleep.svg" class="card-icon" alt="Sleep">
+          <div class="card-title">Sleep</div>
+          <div class="card-score" id="sleep-card">0</div>
+        </div>
+        <div class="card" data-domain="fitness">
+          <img src="icons/fitness.svg" class="card-icon" alt="Fitness">
+          <div class="card-title">Fitness</div>
+          <div class="card-score" id="fitness-card">0</div>
+        </div>
+        <div class="card" data-domain="mind">
+          <img src="icons/mind.svg" class="card-icon" alt="Mind">
+          <div class="card-title">Mind</div>
+          <div class="card-score" id="mind-card">0</div>
+        </div>
+        <div class="card" data-domain="spirit">
+          <img src="icons/spirit.svg" class="card-icon" alt="Spirit">
+          <div class="card-title">Spirit</div>
+          <div class="card-score" id="spirit-card">0</div>
+        </div>
       </div>
-      <div class="card" data-domain="fitness">
-        <img src="icons/fitness.svg" class="card-icon" alt="Fitness">
-        <div class="card-title">Fitness</div>
-        <div class="card-score" id="fitness-card">0</div>
+    </section>
+
+    <section class="page page--vision" id="vision-page" data-page="vision" aria-label="Vision roadmap" hidden>
+      <header class="page-header">
+        <div class="page-kicker">Long view</div>
+        <h1 class="page-title">Vision roadmap</h1>
+        <p class="page-subtitle">Translate purpose into clear horizons, tangible outcomes, and rhythms that keep the mission vivid every day.</p>
+      </header>
+
+      <div class="vision-grid">
+        <article class="vision-card vision-card--highlight">
+          <h2 class="vision-card__title">North star statement</h2>
+          <p class="vision-card__body">Design a well-balanced life that compounds energy, clarity, and generosity so every commitment receives the very best of me.</p>
+          <ul class="vision-pillars" aria-label="Vision pillars">
+            <li class="vision-pillars__item">Lead with calm confidence</li>
+            <li class="vision-pillars__item">Build enduring systems and products</li>
+            <li class="vision-pillars__item">Invest deeply in relationships</li>
+          </ul>
+        </article>
+
+        <article class="vision-card">
+          <h2 class="vision-card__title">12-month horizons</h2>
+          <dl class="vision-horizons">
+            <div class="vision-horizons__item">
+              <dt>Health</dt>
+              <dd>Consistent 90+ day streak meeting sleep, recovery, and training targets.</dd>
+            </div>
+            <div class="vision-horizons__item">
+              <dt>Mind</dt>
+              <dd>Publish two long-form essays and complete one immersive learning sprint.</dd>
+            </div>
+            <div class="vision-horizons__item">
+              <dt>Spirit</dt>
+              <dd>Create a weekly renewal ritual that blends reflection, connection, and service.</dd>
+            </div>
+          </dl>
+        </article>
+
+        <article class="vision-card">
+          <h2 class="vision-card__title">Operating principles</h2>
+          <ul class="vision-list">
+            <li><span>Default to clarity.</span> Articulate the why, the win, and the next action.</li>
+            <li><span>Measure what matters.</span> Pair qualitative reflection with meaningful metrics.</li>
+            <li><span>Protect recovery.</span> Guard deep rest, solitude, and family time as strategic assets.</li>
+            <li><span>Practice generosity.</span> Offer encouragement, insight, or help in every interaction.</li>
+          </ul>
+        </article>
+
+        <article class="vision-card vision-card--progress">
+          <h2 class="vision-card__title">Quarterly focus</h2>
+          <div class="vision-progress" role="list">
+            <div class="vision-progress__item" role="listitem">
+              <div class="vision-progress__meta">
+                <span class="vision-progress__label">Q1 • Foundation</span>
+                <span class="vision-progress__value">72%</span>
+              </div>
+              <div class="vision-progress__bar" aria-hidden="true">
+                <span style="width:72%"></span>
+              </div>
+              <p class="vision-progress__description">Dial-in the sleep and training cadence while documenting the playbook.</p>
+            </div>
+            <div class="vision-progress__item" role="listitem">
+              <div class="vision-progress__meta">
+                <span class="vision-progress__label">Q2 • Amplify</span>
+                <span class="vision-progress__value">38%</span>
+              </div>
+              <div class="vision-progress__bar" aria-hidden="true">
+                <span style="width:38%"></span>
+              </div>
+              <p class="vision-progress__description">Ship two thought-leadership pieces and anchor a monthly mastermind session.</p>
+            </div>
+            <div class="vision-progress__item" role="listitem">
+              <div class="vision-progress__meta">
+                <span class="vision-progress__label">Q3 • Deepen</span>
+                <span class="vision-progress__value">Planning</span>
+              </div>
+              <div class="vision-progress__bar vision-progress__bar--empty" aria-hidden="true">
+                <span style="width:12%"></span>
+              </div>
+              <p class="vision-progress__description">Map a service project and plan an unplugged retreat focused on renewal.</p>
+            </div>
+          </div>
+        </article>
       </div>
-      <div class="card" data-domain="mind">
-        <img src="icons/mind.svg" class="card-icon" alt="Mind">
-        <div class="card-title">Mind</div>
-        <div class="card-score" id="mind-card">0</div>
+
+      <section class="vision-timeline" aria-label="Milestones timeline">
+        <h2 class="vision-card__title">Milestones</h2>
+        <ol class="timeline">
+          <li class="timeline__item">
+            <div class="timeline__marker">April</div>
+            <div class="timeline__content">
+              <h3>Wellness review</h3>
+              <p>Evaluate biometrics and coaching feedback, then recalibrate the training block.</p>
+            </div>
+          </li>
+          <li class="timeline__item">
+            <div class="timeline__marker">July</div>
+            <div class="timeline__content">
+              <h3>Thought leadership drop</h3>
+              <p>Release long-form essay and companion toolkit to the community.</p>
+            </div>
+          </li>
+          <li class="timeline__item">
+            <div class="timeline__marker">October</div>
+            <div class="timeline__content">
+              <h3>Renewal retreat</h3>
+              <p>48-hour retreat with digital fast, gratitude practice, and future-state planning.</p>
+            </div>
+          </li>
+        </ol>
+      </section>
+    </section>
+
+    <section class="page page--gratitude" id="gratitude-page" data-page="gratitude" aria-label="Gratitude journal" hidden>
+      <header class="page-header">
+        <div class="page-kicker">Perspective</div>
+        <h1 class="page-title">Gratitude studio</h1>
+        <p class="page-subtitle">Capture bright spots, celebrate small wins, and curate reminders that keep you anchored in abundance.</p>
+      </header>
+
+      <div class="gratitude-layout">
+        <section class="gratitude-card gratitude-card--primary" aria-labelledby="gratitude-today">
+          <div class="gratitude-card__header">
+            <h2 id="gratitude-today">Today's snapshot</h2>
+            <span class="gratitude-date" id="gratitude-date">April 12 • Day 102</span>
+          </div>
+          <ul class="gratitude-highlights">
+            <li>
+              <h3>Energy spark</h3>
+              <p>Sunrise run felt strong and calm — first negative split of the training block.</p>
+            </li>
+            <li>
+              <h3>Relationship win</h3>
+              <p>Coffee with Avery turned into a deep conversation about purpose and pace.</p>
+            </li>
+            <li>
+              <h3>Creative moment</h3>
+              <p>Sketched a new dashboard layout that simplifies weekly review dramatically.</p>
+            </li>
+          </ul>
+        </section>
+
+        <section class="gratitude-card" aria-labelledby="gratitude-prompts">
+          <h2 id="gratitude-prompts">Prompt library</h2>
+          <div class="prompt-list">
+            <article class="prompt">
+              <h3>Anchor</h3>
+              <p>Who quietly supports your growth? Send a note acknowledging their impact.</p>
+            </article>
+            <article class="prompt">
+              <h3>Reframe</h3>
+              <p>What challenge taught you something useful this week?</p>
+            </article>
+            <article class="prompt">
+              <h3>Moment</h3>
+              <p>Capture one sensory detail from today that felt restorative.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="gratitude-card gratitude-card--journal" aria-labelledby="gratitude-journal">
+          <div class="gratitude-card__header">
+            <h2 id="gratitude-journal">Journal queue</h2>
+            <button class="gratitude-action" type="button">Start 5-minute session</button>
+          </div>
+          <p class="gratitude-intro">Use these prompts to seed your next entry. Capture three specifics and close with one generous action you can take tomorrow.</p>
+          <div class="journal-queue">
+            <div class="journal-queue__item">
+              <span class="journal-queue__tag">Relationships</span>
+              <p>Write about someone whose presence made today lighter.</p>
+            </div>
+            <div class="journal-queue__item">
+              <span class="journal-queue__tag">Progress</span>
+              <p>Document a small step that moved a big dream forward.</p>
+            </div>
+            <div class="journal-queue__item">
+              <span class="journal-queue__tag">Service</span>
+              <p>Identify one way to pay today's goodness forward.</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="gratitude-card gratitude-card--log" aria-labelledby="gratitude-log">
+          <div class="gratitude-card__header">
+            <h2 id="gratitude-log">Recent entries</h2>
+            <button class="gratitude-action" type="button">View archive</button>
+          </div>
+          <ul class="gratitude-log">
+            <li>
+              <time datetime="2024-04-11">Apr 11</time>
+              <p>Team celebrated our launch milestone — felt proud of the collective effort.</p>
+            </li>
+            <li>
+              <time datetime="2024-04-10">Apr 10</time>
+              <p>Neighbor dropped off homemade soup while I was heads-down shipping.</p>
+            </li>
+            <li>
+              <time datetime="2024-04-09">Apr 9</time>
+              <p>Read a note from a customer describing how the product simplified their day.</p>
+            </li>
+            <li>
+              <time datetime="2024-04-08">Apr 8</time>
+              <p>Watched the sunset with family and unplugged without guilt.</p>
+            </li>
+          </ul>
+        </section>
       </div>
-      <div class="card" data-domain="spirit">
-        <img src="icons/spirit.svg" class="card-icon" alt="Spirit">
-        <div class="card-title">Spirit</div>
-        <div class="card-score" id="spirit-card">0</div>
-      </div>
-    </div>
+    </section>
   </main>
 
   <footer class="app-footer">
     <nav class="bottom-nav">
-      <button class="nav-btn" aria-label="Vision">
+      <button class="nav-btn" type="button" data-target="vision" aria-label="Vision" aria-controls="vision-page" aria-selected="false">
         <img src="icons/vision.svg" class="nav-icon" alt="">
         <span class="nav-label">Vision</span>
       </button>
-      <button class="nav-btn active" aria-label="Home">
+      <button class="nav-btn active" type="button" data-target="home" aria-label="Home" aria-controls="home-page" aria-selected="true">
         <img src="icons/drop_icon.svg" class="nav-icon" alt="">
         <span class="nav-label">Home</span>
       </button>
-      <button class="nav-btn" aria-label="Gratitude">
+      <button class="nav-btn" type="button" data-target="gratitude" aria-label="Gratitude" aria-controls="gratitude-page" aria-selected="false">
         <img src="icons/gratitude.svg" class="nav-icon" alt="">
         <span class="nav-label">Gratitude</span>
       </button>

--- a/V3.1/styles.css
+++ b/V3.1/styles.css
@@ -68,7 +68,13 @@ body {
 }
 .app-header { padding-top: calc(16px + env(safe-area-inset-top)); }
 .app-footer { border-bottom: none; border-top: 1px solid var(--color-border); padding: 8px; padding-bottom: calc(8px + env(safe-area-inset-bottom)); }
-.app-main { flex: 1; display: flex; align-items: center; justify-content: center; padding: 24px; background: radial-gradient(circle at top, var(--color-bg-gradient-start) 0%, var(--color-bg-gradient-end) 100%); }
+.app-main {
+  flex: 1;
+  padding: 24px;
+  padding-bottom: 120px;
+  background: radial-gradient(circle at top, var(--color-bg-gradient-start) 0%, var(--color-bg-gradient-end) 100%);
+  overflow-y: auto;
+}
 
 /* === HEADER === */
 .date { font-size: 14px; color: var(--color-text-secondary); margin-bottom: 16px; font-weight: 500; }
@@ -212,7 +218,446 @@ body {
 /* Developer UI: small pill and toast (styling kept further down) */
 
 /* === MAIN GRID & CARDS === */
-.main-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; width: 100%; max-width: 420px; }
+.main-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; width: 100%; max-width: 420px; margin: 0 auto; }
+
+/* === PAGE FRAMEWORK === */
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  width: 100%;
+  max-width: 860px;
+  margin: 0 auto;
+  flex: 1;
+}
+
+.page[hidden] { display: none !important; }
+
+.page--home { align-items: center; justify-content: center; min-height: 420px; }
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 4px 0;
+}
+
+.page-kicker {
+  font-size: 12px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+}
+
+.page-title {
+  font-size: clamp(28px, 6vw, 40px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.page-subtitle {
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+  max-width: 620px;
+}
+
+/* === VISION PAGE === */
+.vision-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.vision-card {
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: relative;
+  overflow: hidden;
+}
+
+.vision-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  background: linear-gradient(135deg, rgba(79,138,245,0.18), transparent 65%);
+}
+
+.vision-card:hover::after { opacity: 1; }
+
+.vision-card--highlight {
+  background: linear-gradient(135deg, rgba(79,138,245,0.18), rgba(79,138,245,0.04));
+  border-color: rgba(79,138,245,0.35);
+}
+
+.vision-card--progress { border-color: rgba(124,58,237,0.35); }
+
+.vision-card__title {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+.vision-card__body {
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--color-text-primary);
+}
+
+.vision-pillars {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.vision-pillars__item {
+  padding-left: 20px;
+  position: relative;
+  color: var(--color-text-secondary);
+}
+
+.vision-pillars__item::before {
+  content: '•';
+  position: absolute;
+  left: 0;
+  color: var(--color-primary);
+}
+
+.vision-horizons {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.vision-horizons__item dt {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  color: var(--color-text-tertiary);
+  margin-bottom: 6px;
+}
+
+.vision-horizons__item dd {
+  margin-left: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.vision-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  list-style: none;
+}
+
+.vision-list li {
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.vision-list li span {
+  display: block;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-primary);
+  margin-bottom: 4px;
+}
+
+.vision-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.vision-progress__item {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.vision-progress__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-tertiary);
+}
+
+.vision-progress__value { font-weight: 700; color: var(--color-text-primary); }
+
+.vision-progress__bar {
+  width: 100%;
+  height: 8px;
+  background: rgba(255,255,255,0.08);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.vision-progress__bar span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(135deg, rgba(63, 171, 252, 0.8), rgba(124, 58, 237, 0.9));
+  border-radius: inherit;
+}
+
+.vision-progress__bar--empty span { background: linear-gradient(135deg, rgba(63, 171, 252, 0.3), rgba(124, 58, 237, 0.35)); }
+
+.vision-progress__description {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.vision-timeline {
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
+}
+
+.timeline {
+  list-style: none;
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  position: relative;
+  padding-left: 24px;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(to bottom, rgba(79,138,245,0.6), rgba(124,58,237,0.6));
+}
+
+.timeline__item {
+  position: relative;
+  padding-left: 16px;
+}
+
+.timeline__marker {
+  position: absolute;
+  left: -24px;
+  top: 2px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+}
+
+.timeline__content h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.timeline__content p {
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+/* === GRATITUDE PAGE === */
+.gratitude-layout {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.gratitude-card {
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.gratitude-card--primary {
+  grid-column: span 2;
+  background: linear-gradient(135deg, rgba(22,163,74,0.15), rgba(59,130,246,0.05));
+  border-color: rgba(22,163,74,0.35);
+}
+
+.gratitude-card--journal { border-color: rgba(79,138,245,0.3); }
+.gratitude-card--log { border-color: rgba(255,255,255,0.08); }
+
+.gratitude-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.gratitude-card__header h2 {
+  font-size: 18px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-tertiary);
+}
+
+.gratitude-date {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+.gratitude-highlights {
+  list-style: none;
+  display: grid;
+  gap: 16px;
+}
+
+.gratitude-highlights h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 6px;
+  color: var(--color-text-primary);
+}
+
+.gratitude-highlights p {
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.prompt-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.prompt {
+  padding: 18px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-2);
+  border: 1px solid rgba(255,255,255,0.04);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.02);
+}
+
+.prompt h3 {
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+  color: var(--color-text-tertiary);
+}
+
+.prompt p { color: var(--color-text-secondary); line-height: 1.6; }
+
+.gratitude-action {
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.gratitude-action:hover {
+  background: var(--color-primary-gradient);
+  color: #fff;
+  border-color: transparent;
+}
+
+.gratitude-intro {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.journal-queue {
+  display: grid;
+  gap: 16px;
+}
+
+.journal-queue__item {
+  padding: 18px;
+  border-radius: var(--radius-md);
+  background: rgba(79,138,245,0.08);
+  border: 1px solid rgba(79,138,245,0.2);
+}
+
+.journal-queue__tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 700;
+  background: rgba(79,138,245,0.2);
+  color: var(--color-text-primary);
+  margin-bottom: 10px;
+}
+
+.journal-queue__item p { color: var(--color-text-primary); line-height: 1.5; }
+
+.gratitude-log {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.gratitude-log li {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+.gratitude-log time {
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--color-text-tertiary);
+}
+
+.gratitude-log p {
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+@media (max-width: 640px) {
+  .gratitude-card--primary { grid-column: span 1; }
+  .gratitude-log li { grid-template-columns: 1fr; }
+  .gratitude-card__header { flex-direction: column; align-items: flex-start; }
+}
 .card {
   background: linear-gradient(145deg, #1f1f24, #18181c);
   border: 1px solid var(--color-border);


### PR DESCRIPTION
## Summary
- convert the home content into a page container and add dedicated Vision and Gratitude sections with rich copy and layout
- expand the design system with page, vision, and gratitude-specific styling to support the new views
- enhance navigation logic to switch sections, refresh the gratitude date, and maintain accessibility states

## Testing
- No automated tests were run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68df3f00dbe48323a552395812f555e6