### PR TITLE
Add vision and gratitude pages to PWA

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -9,7 +9,9 @@ document.addEventListener('DOMContentLoaded', () => {
     state: {},
     defaults: {
       wake: '', rest: '', run: 0, strength: false, skill: false,
-      read: false, write: false, quadrant: 0, meditation: false
+      read: false, write: false, quadrant: 0, meditation: false,
+      visionTheme: '', visionSleepFocus: '', visionFitnessFocus: '',
+      visionMindFocus: '', visionSpiritFocus: ''
     },
     
     init() {
@@ -26,7 +28,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (key in this.state) {
         this.state[key] = value;
         this.save();
-        App.updateScores();
+        if (!key.startsWith('vision')) {
+          App.updateScores();
+        }
       }
     }
   };
@@ -37,10 +41,31 @@ document.addEventListener('DOMContentLoaded', () => {
       cards: document.querySelectorAll('.card'),
       overlays: document.querySelectorAll('.overlay'),
       navButtons: document.querySelectorAll('.nav-btn'),
+      pages: document.querySelectorAll('[data-page]'),
       loadingOverlay: document.getElementById('loading-overlay'),
       installButton: document.getElementById('install-button'),
       devPill: document.getElementById('dev-pill'),
       devToast: document.getElementById('dev-toast'),
+      visionInputs: {
+        theme: document.getElementById('vision-theme'),
+        sleep: document.getElementById('vision-sleep-focus'),
+        fitness: document.getElementById('vision-fitness-focus'),
+        mind: document.getElementById('vision-mind-focus'),
+        spirit: document.getElementById('vision-spirit-focus')
+      },
+      gratitude: {
+        topDomain: document.getElementById('gratitude-top-domain'),
+        topScore: document.getElementById('gratitude-top-score'),
+        topDetail: document.getElementById('gratitude-top-detail'),
+        focusDomain: document.getElementById('gratitude-focus-domain'),
+        focusScore: document.getElementById('gratitude-focus-score'),
+        focusDetail: document.getElementById('gratitude-focus-detail'),
+        momentumDetail: document.getElementById('gratitude-momentum-detail'),
+        sleepSummary: document.getElementById('gratitude-sleep-summary'),
+        runSummary: document.getElementById('gratitude-run-summary'),
+        meditationSummary: document.getElementById('gratitude-meditation-summary'),
+        progressBars: document.querySelectorAll('[data-progress-domain]')
+      },
       scoreDisplays: {
         sleep: { score: document.getElementById('sleep-score'), card: document.getElementById('sleep-card') },
         fitness: { score: document.getElementById('fitness-score'), card: document.getElementById('fitness-card') },
@@ -59,6 +84,7 @@ document.addEventListener('DOMContentLoaded', () => {
         this.elements.scoreDisplays[domain].score.textContent = scores[domain];
         this.elements.scoreDisplays[domain].card.textContent = scores[domain];
       }
+      this.renderGratitude(scores);
     },
 
     showLoading(show = true) {
@@ -139,15 +165,65 @@ document.addEventListener('DOMContentLoaded', () => {
       this.elements.dateDisplay.textContent = new Date().toLocaleDateString('en-US', {
         weekday: 'long', month: 'long', day: 'numeric'
       });
+    },
+
+    setVisionFields(state) {
+      const { visionInputs } = this.elements;
+      if (!visionInputs) return;
+      if (visionInputs.theme) visionInputs.theme.value = state.visionTheme || '';
+      if (visionInputs.sleep) visionInputs.sleep.value = state.visionSleepFocus || '';
+      if (visionInputs.fitness) visionInputs.fitness.value = state.visionFitnessFocus || '';
+      if (visionInputs.mind) visionInputs.mind.value = state.visionMindFocus || '';
+      if (visionInputs.spirit) visionInputs.spirit.value = state.visionSpiritFocus || '';
+    },
+
+    renderGratitude(scores) {
+      const {
+        topDomain, topScore, topDetail,
+        focusDomain, focusScore, focusDetail,
+        momentumDetail, sleepSummary, runSummary,
+        meditationSummary, progressBars
+      } = this.elements.gratitude;
+
+      if (!topDomain) return;
+
+      const insights = App.generateInsights(scores);
+
+      topDomain.textContent = insights.topDomain.label;
+      topScore.textContent = insights.topDomain.score;
+      topDetail.textContent = insights.topDomain.detail;
+
+      focusDomain.textContent = insights.focusDomain.label;
+      focusScore.textContent = insights.focusDomain.score;
+      focusDetail.textContent = insights.focusDomain.detail;
+
+      momentumDetail.textContent = insights.momentum;
+      sleepSummary.textContent = insights.sleepSummary;
+      runSummary.textContent = insights.runSummary;
+      meditationSummary.textContent = insights.meditationSummary;
+
+      progressBars.forEach(bar => {
+        const domain = bar.dataset.progressDomain;
+        if (domain in scores) {
+          bar.style.setProperty('--progress', `${scores[domain]}%`);
+          bar.setAttribute('aria-valuenow', scores[domain]);
+          const fill = bar.querySelector('.progress-fill');
+          const scoreEl = bar.querySelector('.progress-score');
+          if (fill) fill.style.width = `${scores[domain]}%`;
+          if (scoreEl) scoreEl.textContent = scores[domain];
+        }
+      });
     }
   };
 
   const App = {
     deferredInstallPrompt: null,
+    currentPage: 'home',
 
     init() {
       Store.init();
       UI.initDate();
+      UI.setVisionFields(Store.state);
       // Show loading overlay with a 5s breath animation synchronized with the overlay hide
       const animDurationMs = 5000; // matches the CSS breath animation duration
       UI.showLoading(true);
@@ -155,6 +231,7 @@ document.addEventListener('DOMContentLoaded', () => {
       this.bindEvents();
       this.registerServiceWorker();
       this.initInstallPrompt();
+      this.showPage('home');
 
       // Hide loading overlay when the breath animation finishes (or fallback after animDurationMs)
       const logo = document.querySelector('.loading-logo');
@@ -299,18 +376,60 @@ document.addEventListener('DOMContentLoaded', () => {
       // Nav buttons
       UI.elements.navButtons.forEach(btn => {
         btn.addEventListener('click', () => {
-          const label = btn.querySelector('.nav-label').textContent;
-          if (label === 'Vision') {
-            alert('Vision page - Coming soon!');
-          } else if (label === 'Gratitude') {
-            alert('Gratitude page - Coming soon!');
-          } else if (label === 'Home') {
-            window.scrollTo({ top: 0, behavior: 'smooth' });
-          }
-          // Update active state
-          UI.elements.navButtons.forEach(b => b.classList.remove('active'));
-          btn.classList.add('active');
+          const page = btn.dataset.page;
+          if (!page) return;
+          this.showPage(page);
         });
+      });
+
+      // Vision inputs
+      Object.entries(UI.elements.visionInputs).forEach(([key, input]) => {
+        if (!input) return;
+        input.addEventListener('input', (event) => {
+          const value = event.target.value.trim();
+          const storeKey = this.mapVisionKey(key);
+          if (storeKey) {
+            Store.update(storeKey, value);
+          }
+        });
+      });
+    },
+
+    mapVisionKey(key) {
+      switch (key) {
+        case 'theme':
+          return 'visionTheme';
+        case 'sleep':
+          return 'visionSleepFocus';
+        case 'fitness':
+          return 'visionFitnessFocus';
+        case 'mind':
+          return 'visionMindFocus';
+        case 'spirit':
+          return 'visionSpiritFocus';
+        default:
+          return null;
+      }
+    },
+
+    showPage(page) {
+      if (!page) return;
+
+      UI.elements.pages.forEach(section => {
+        section.classList.toggle('active', section.dataset.page === page);
+      });
+
+      this.currentPage = page;
+      this.updateNavState(page);
+
+      if (page === 'home') {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }
+    },
+
+    updateNavState(page) {
+      UI.elements.navButtons.forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.page === page);
       });
     },
 
@@ -353,6 +472,90 @@ document.addEventListener('DOMContentLoaded', () => {
       else if (quadrant === 3 || quadrant === 4) score += 25;
       if (meditation) score += 50;
       return Math.min(100, score);
+    },
+
+    calculateSleepHours() {
+      const { wake, rest } = Store.state;
+      if (!wake || !rest) return null;
+      const [wh, wm] = wake.split(':').map(Number);
+      const [rh, rm] = rest.split(':').map(Number);
+      if ([wh, wm, rh, rm].some(v => isNaN(v))) return null;
+      const wakeMins = wh * 60 + wm;
+      const restMins = rh * 60 + rm;
+      const duration = restMins < wakeMins ? (1440 - wakeMins + restMins) : (restMins - wakeMins);
+      return Math.round((duration / 60) * 10) / 10;
+    },
+
+    generateInsights(scores) {
+      const domainLabels = {
+        sleep: 'Sleep',
+        fitness: 'Fitness',
+        mind: 'Mind',
+        spirit: 'Spirit'
+      };
+
+      const entries = Object.entries(scores);
+      const top = entries.reduce((acc, curr) => (curr[1] > acc[1] ? curr : acc));
+      const bottom = entries.reduce((acc, curr) => (curr[1] < acc[1] ? curr : acc));
+
+      const narrative = {
+        sleep: {
+          high: 'Your routines are setting the tone for energised mornings.',
+          low: 'Try reinforcing your wind-down cues to unlock deeper rest.'
+        },
+        fitness: {
+          high: 'Your training block is building real momentum—keep riding it.',
+          low: 'A fresh plan for progressive sessions could reignite this lane.'
+        },
+        mind: {
+          high: 'Curiosity is compounding—your inputs are sharpening thinking.',
+          low: 'Schedule protected time for reading or writing to refuel clarity.'
+        },
+        spirit: {
+          high: 'You’re staying grounded and connected to what matters most.',
+          low: 'Experiment with a micro-practice to recenter during transitions.'
+        }
+      };
+
+      const topDomain = {
+        label: domainLabels[top[0]],
+        score: top[1],
+        detail: narrative[top[0]].high
+      };
+
+      const focusDomain = {
+        label: domainLabels[bottom[0]],
+        score: bottom[1],
+        detail: narrative[bottom[0]].low
+      };
+
+      const sleepHours = this.calculateSleepHours();
+      const sleepSummary = sleepHours
+        ? `Averaged ${sleepHours}h between rest and wake—calibrate toward 7.5h for steady energy.`
+        : 'Log wake and rest windows to unlock personalised sleep feedback.';
+
+      const runKm = Store.state.run;
+      const runSummary = runKm > 0
+        ? `Logged ${runKm} km. Consider a stride session or recovery run to stay balanced.`
+        : 'No distance logged yet—set a target run to spark momentum.';
+
+      const meditationSummary = Store.state.meditation
+        ? 'Meditation checked in—carry that presence into high-leverage moments.'
+        : 'A two-minute pause could reset your baseline before the next sprint.';
+
+      const averageScore = Math.round(entries.reduce((total, [, val]) => total + val, 0) / entries.length);
+      const momentum = averageScore >= 75
+        ? `Strong average (${averageScore}) across domains—build on what’s working.`
+        : `Average sits at ${averageScore}. Choose one ritual to upgrade and lift the whole system.`;
+
+      return {
+        topDomain,
+        focusDomain,
+        sleepSummary,
+        runSummary,
+        meditationSummary,
+        momentum
+      };
     },
 
     registerServiceWorker() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -69,41 +69,207 @@
   </header>
 
   <main class="app-main">
-    <div class="main-grid">
-      <div class="card" data-domain="sleep">
-        <img src="icons/sleep.svg" class="card-icon" alt="Sleep">
-        <div class="card-title">Sleep</div>
-        <div class="card-score" id="sleep-card">0</div>
+    <section class="page page--home active" data-page="home" aria-labelledby="home-heading">
+      <h1 id="home-heading" class="visually-hidden">Daily Domain Tracker</h1>
+      <div class="main-grid">
+        <div class="card" data-domain="sleep">
+          <img src="icons/sleep.svg" class="card-icon" alt="Sleep">
+          <div class="card-title">Sleep</div>
+          <div class="card-score" id="sleep-card">0</div>
+        </div>
+        <div class="card" data-domain="fitness">
+          <img src="icons/fitness.svg" class="card-icon" alt="Fitness">
+          <div class="card-title">Fitness</div>
+          <div class="card-score" id="fitness-card">0</div>
+        </div>
+        <div class="card" data-domain="mind">
+          <img src="icons/mind.svg" class="card-icon" alt="Mind">
+          <div class="card-title">Mind</div>
+          <div class="card-score" id="mind-card">0</div>
+        </div>
+        <div class="card" data-domain="spirit">
+          <img src="icons/spirit.svg" class="card-icon" alt="Spirit">
+          <div class="card-title">Spirit</div>
+          <div class="card-score" id="spirit-card">0</div>
+        </div>
       </div>
-      <div class="card" data-domain="fitness">
-        <img src="icons/fitness.svg" class="card-icon" alt="Fitness">
-        <div class="card-title">Fitness</div>
-        <div class="card-score" id="fitness-card">0</div>
+    </section>
+
+    <section class="page page--vision" data-page="vision" aria-labelledby="vision-heading">
+      <div class="page-header">
+        <p class="page-eyebrow">Vision</p>
+        <h2 id="vision-heading">Set the tone for the week</h2>
+        <p class="page-subtitle">Define where your attention goes in each domain so execution feels intentional.</p>
       </div>
-      <div class="card" data-domain="mind">
-        <img src="icons/mind.svg" class="card-icon" alt="Mind">
-        <div class="card-title">Mind</div>
-        <div class="card-score" id="mind-card">0</div>
+
+      <article class="vision-intent">
+        <h3>Weekly North Star</h3>
+        <p>Anchor the week with a single theme or feeling you want to cultivate.</p>
+        <label class="input-label" for="vision-theme">Theme</label>
+        <textarea id="vision-theme" class="vision-textarea" rows="3" placeholder="Example: Protect deep sleep and prime creative energy." maxlength="200"></textarea>
+        <p class="vision-tip">Keep it short and memorable—something you can revisit on the fly.</p>
+      </article>
+
+      <div class="vision-grid">
+        <article class="vision-card" data-domain="sleep">
+          <header class="vision-card__header">
+            <img src="icons/sleep.svg" alt="" aria-hidden="true">
+            <div>
+              <h3>Sleep</h3>
+              <p>Protect recovery so mornings start steady.</p>
+            </div>
+          </header>
+          <label class="input-label" for="vision-sleep-focus">Focus statement</label>
+          <textarea id="vision-sleep-focus" class="vision-textarea" rows="3" placeholder="Lights out by 10:30pm with devices off." maxlength="160"></textarea>
+          <ul class="vision-prompts">
+            <li>What habit ensures you wake sharp?</li>
+            <li>Where can you remove friction from the wind-down?</li>
+          </ul>
+        </article>
+
+        <article class="vision-card" data-domain="fitness">
+          <header class="vision-card__header">
+            <img src="icons/fitness.svg" alt="" aria-hidden="true">
+            <div>
+              <h3>Fitness</h3>
+              <p>Set a clear training rhythm and win the reps.</p>
+            </div>
+          </header>
+          <label class="input-label" for="vision-fitness-focus">Focus statement</label>
+          <textarea id="vision-fitness-focus" class="vision-textarea" rows="3" placeholder="Two strength blocks + one tempo run." maxlength="160"></textarea>
+          <ul class="vision-prompts">
+            <li>Which session creates the biggest return?</li>
+            <li>How will you celebrate consistency?</li>
+          </ul>
+        </article>
+
+        <article class="vision-card" data-domain="mind">
+          <header class="vision-card__header">
+            <img src="icons/mind.svg" alt="" aria-hidden="true">
+            <div>
+              <h3>Mind</h3>
+              <p>Curate inputs that sharpen thinking.</p>
+            </div>
+          </header>
+          <label class="input-label" for="vision-mind-focus">Focus statement</label>
+          <textarea id="vision-mind-focus" class="vision-textarea" rows="3" placeholder="Read 20 pages before checking messages." maxlength="160"></textarea>
+          <ul class="vision-prompts">
+            <li>Which questions are you exploring?</li>
+            <li>Where can you trade scrolling for study?</li>
+          </ul>
+        </article>
+
+        <article class="vision-card" data-domain="spirit">
+          <header class="vision-card__header">
+            <img src="icons/spirit.svg" alt="" aria-hidden="true">
+            <div>
+              <h3>Spirit</h3>
+              <p>Stay rooted in purpose and connection.</p>
+            </div>
+          </header>
+          <label class="input-label" for="vision-spirit-focus">Focus statement</label>
+          <textarea id="vision-spirit-focus" class="vision-textarea" rows="3" placeholder="Daily gratitude note before shutting down work." maxlength="160"></textarea>
+          <ul class="vision-prompts">
+            <li>What practice keeps you centred?</li>
+            <li>Who can you intentionally pour into?</li>
+          </ul>
+        </article>
       </div>
-      <div class="card" data-domain="spirit">
-        <img src="icons/spirit.svg" class="card-icon" alt="Spirit">
-        <div class="card-title">Spirit</div>
-        <div class="card-score" id="spirit-card">0</div>
+    </section>
+
+    <section class="page page--gratitude" data-page="gratitude" aria-labelledby="gratitude-heading">
+      <div class="page-header">
+        <p class="page-eyebrow">Gratitude</p>
+        <h2 id="gratitude-heading">Review the results with clarity</h2>
+        <p class="page-subtitle">Surface meaningful progress and the next nudge—no generic dashboards.</p>
       </div>
-    </div>
+
+      <div class="insights-grid">
+        <article class="insight-card insight-card--highlight">
+          <div class="card-eyebrow">Highlights</div>
+          <h3>Standout Domain</h3>
+          <div class="insight-metric">
+            <span id="gratitude-top-domain" class="insight-metric__label">Sleep</span>
+            <span id="gratitude-top-score" class="insight-metric__value">0</span>
+          </div>
+          <p id="gratitude-top-detail" class="insight-detail">Momentum copy.</p>
+        </article>
+
+        <article class="insight-card insight-card--focus">
+          <div class="card-eyebrow">Next Focus</div>
+          <h3>Sharpen This Area</h3>
+          <div class="insight-metric">
+            <span id="gratitude-focus-domain" class="insight-metric__label">Fitness</span>
+            <span id="gratitude-focus-score" class="insight-metric__value">0</span>
+          </div>
+          <p id="gratitude-focus-detail" class="insight-detail">Opportunity copy.</p>
+        </article>
+
+        <article class="insight-card insight-card--momentum">
+          <div class="card-eyebrow">Momentum</div>
+          <h3>Weekly Pulse</h3>
+          <p id="gratitude-momentum-detail" class="insight-detail">Momentum narrative.</p>
+        </article>
+
+        <article class="insight-card insight-card--scoreboard">
+          <div class="card-eyebrow">Scoreboard</div>
+          <h3>Domain Scores</h3>
+          <div class="progress-list">
+            <div class="progress-row" data-progress-domain="sleep" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+              <span class="progress-label">Sleep</span>
+              <div class="progress-bar">
+                <div class="progress-fill"></div>
+              </div>
+              <span class="progress-score">0</span>
+            </div>
+            <div class="progress-row" data-progress-domain="fitness" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+              <span class="progress-label">Fitness</span>
+              <div class="progress-bar">
+                <div class="progress-fill"></div>
+              </div>
+              <span class="progress-score">0</span>
+            </div>
+            <div class="progress-row" data-progress-domain="mind" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+              <span class="progress-label">Mind</span>
+              <div class="progress-bar">
+                <div class="progress-fill"></div>
+              </div>
+              <span class="progress-score">0</span>
+            </div>
+            <div class="progress-row" data-progress-domain="spirit" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+              <span class="progress-label">Spirit</span>
+              <div class="progress-bar">
+                <div class="progress-fill"></div>
+              </div>
+              <span class="progress-score">0</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="insight-card insight-card--reflections">
+          <div class="card-eyebrow">Micro Reflections</div>
+          <h3>Signals Worth Noting</h3>
+          <ul class="insight-list">
+            <li id="gratitude-sleep-summary">Sleep insight.</li>
+            <li id="gratitude-run-summary">Run insight.</li>
+            <li id="gratitude-meditation-summary">Meditation insight.</li>
+          </ul>
+        </article>
+      </div>
+    </section>
   </main>
 
   <footer class="app-footer">
     <nav class="bottom-nav">
-      <button class="nav-btn" aria-label="Vision">
+      <button class="nav-btn" data-page="vision" aria-label="Vision">
         <img src="icons/vision.svg" class="nav-icon" alt="">
         <span class="nav-label">Vision</span>
       </button>
-      <button class="nav-btn active" aria-label="Home">
+      <button class="nav-btn active" data-page="home" aria-label="Home">
         <img src="icons/drop_icon.svg" class="nav-icon" alt="">
         <span class="nav-label">Home</span>
       </button>
-      <button class="nav-btn" aria-label="Gratitude">
+      <button class="nav-btn" data-page="gratitude" aria-label="Gratitude">
         <img src="icons/gratitude.svg" class="nav-icon" alt="">
         <span class="nav-label">Gratitude</span>
       </button>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -75,9 +75,7 @@ body {
 }
 .app-main {
   flex: 1 1 auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: block;
   padding: 24px;
   background: radial-gradient(circle at top, var(--color-bg-gradient-start) 0%, var(--color-bg-gradient-end) 100%);
   overflow-y: auto;
@@ -161,12 +159,295 @@ body {
   line-height: 1;
 }
 
-.score-name { 
-  font-size: 11px; 
-  color: var(--color-text-tertiary); 
+.score-name {
+  font-size: 11px;
+  color: var(--color-text-tertiary);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.5px;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  height: 1px; width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap;
+}
+
+/* === PAGE LAYOUTS === */
+.page {
+  display: none;
+  animation: fadeUp 240ms ease;
+}
+
+.page.active {
+  display: block;
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 24px;
+}
+
+.page-eyebrow {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--color-primary);
+}
+
+.page-header h2 {
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.page-subtitle {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+/* === HOME PAGE === */
+.page--home .main-grid {
+  margin-top: 12px;
+}
+
+/* === VISION PAGE === */
+.vision-intent,
+.vision-card {
+  background: linear-gradient(140deg, rgba(44, 52, 79, 0.35), rgba(27, 29, 34, 0.6));
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-xl);
+  padding: 20px;
+  box-shadow: var(--shadow-md);
+  margin-bottom: 20px;
+}
+
+.vision-intent h3,
+.vision-card h3 {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.vision-intent p,
+.vision-card p {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.vision-textarea {
+  width: 100%;
+  margin-top: 12px;
+  border-radius: var(--radius-lg);
+  background: rgba(12, 14, 20, 0.6);
+  border: 1px solid rgba(79, 138, 245, 0.25);
+  color: var(--color-text-primary);
+  padding: 12px 14px;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  resize: none;
+  transition: border var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.vision-textarea:focus {
+  outline: none;
+  border-color: var(--color-border-focus);
+  box-shadow: 0 0 0 2px rgba(79, 138, 245, 0.15);
+}
+
+.vision-tip {
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+}
+
+.vision-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.vision-card__header {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.vision-card__header img {
+  width: 40px;
+  height: 40px;
+  filter: drop-shadow(0 6px 12px rgba(0, 0, 0, 0.45));
+}
+
+.vision-prompts {
+  margin-top: 16px;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.vision-prompts li {
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  display: flex;
+  gap: 8px;
+}
+
+.vision-prompts li::before {
+  content: '\2022';
+  color: var(--color-primary);
+}
+
+/* === GRATITUDE PAGE === */
+.insights-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.insight-card {
+  background: linear-gradient(140deg, rgba(23, 26, 38, 0.85), rgba(16, 18, 24, 0.75));
+  border-radius: var(--radius-xl);
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.insight-card--highlight {
+  border-color: rgba(79, 138, 245, 0.35);
+  background: linear-gradient(150deg, rgba(59, 130, 246, 0.25), rgba(12, 14, 24, 0.85));
+}
+
+.insight-card--focus {
+  border-color: rgba(239, 68, 68, 0.35);
+  background: linear-gradient(150deg, rgba(239, 68, 68, 0.18), rgba(12, 14, 24, 0.85));
+}
+
+.insight-card--momentum {
+  background: linear-gradient(150deg, rgba(34, 197, 94, 0.18), rgba(12, 14, 24, 0.85));
+}
+
+.card-eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+  font-weight: 600;
+}
+
+.insight-card h3 {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.insight-detail {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+}
+
+.insight-metric {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.insight-metric__label {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.insight-metric__value {
+  font-family: var(--font-mono);
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.progress-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.progress-row {
+  display: grid;
+  grid-template-columns: 80px 1fr 48px;
+  align-items: center;
+  gap: 12px;
+}
+
+.progress-label {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.progress-bar {
+  position: relative;
+  height: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  position: absolute;
+  top: 0; left: 0;
+  height: 100%;
+  width: 0%;
+  background: var(--color-primary-gradient);
+  transition: width 260ms ease;
+}
+
+.progress-score {
+  font-family: var(--font-mono);
+  font-size: 14px;
+}
+
+.insight-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.insight-list li {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+  border-left: 2px solid rgba(79, 138, 245, 0.35);
+  padding-left: 12px;
+}
+
+@media (min-width: 480px) {
+  .vision-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .insights-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .insight-card--momentum,
+  .insight-card--reflections {
+    grid-column: span 2;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- add a Vision planner view with weekly focus inputs that persist to local storage
- create a Gratitude review view with dynamic insights, score visualisations, and micro reflections
- refresh navigation and styling to support the multi-page experience with professional presentation

## Testing
- python3 -m http.server 8000 (manual verification of pages)


------
https://chatgpt.com/codex/tasks/task_e_68df489de48083238fa89166a0b2c172