### PR TITLE
Add data backup tools and navigation fixes for Sprint 1

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -32,6 +32,38 @@ document.addEventListener('DOMContentLoaded', () => {
           App.updateScores();
         }
       }
+    },
+
+    validateImport(payload) {
+      if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        return false;
+      }
+
+      const allowedKeys = Object.keys(this.defaults);
+      return Object.keys(payload).every(key => {
+        if (!allowedKeys.includes(key)) return false;
+        const defaultValue = this.defaults[key];
+        const value = payload[key];
+
+        if (value === null || value === undefined) return false;
+
+        const defaultType = typeof defaultValue;
+        if (defaultType === 'boolean') {
+          return typeof value === 'boolean';
+        }
+        if (defaultType === 'number') {
+          return typeof value === 'number' && Number.isFinite(value);
+        }
+        if (defaultType === 'string') {
+          return typeof value === 'string';
+        }
+        return false;
+      });
+    },
+
+    merge(payload) {
+      this.state = { ...this.defaults, ...this.state, ...payload };
+      this.save();
     }
   };
 
@@ -46,6 +78,12 @@ document.addEventListener('DOMContentLoaded', () => {
       installButton: document.getElementById('install-button'),
       devPill: document.getElementById('dev-pill'),
       devToast: document.getElementById('dev-toast'),
+      appToast: document.getElementById('app-toast'),
+      dataControls: {
+        exportBtn: document.getElementById('export-data-btn'),
+        importBtn: document.getElementById('import-data-btn'),
+        importInput: document.getElementById('import-data-input')
+      },
       visionInputs: {
         theme: document.getElementById('vision-theme'),
         sleep: document.getElementById('vision-sleep-focus'),
@@ -79,6 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
         runValue: document.getElementById('run-value'),
       }
     },
+    toastTimer: null,
 
     renderScores(scores) {
       const announcements = [];
@@ -136,6 +175,19 @@ document.addEventListener('DOMContentLoaded', () => {
       t.textContent = msg;
       t.classList.add('show');
       setTimeout(() => t.classList.remove('show'), ms);
+    },
+
+    notify(message, ms = 2000) {
+      const toast = this.elements.appToast;
+      if (!toast) return;
+      toast.textContent = message;
+      toast.classList.add('show');
+      if (this.toastTimer) {
+        clearTimeout(this.toastTimer);
+      }
+      this.toastTimer = setTimeout(() => {
+        toast.classList.remove('show');
+      }, ms);
     },
 
     toggleOverlay(domain, show = true) {
@@ -346,6 +398,63 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     },
 
+    handleExport() {
+      try {
+        const data = JSON.stringify(Store.state, null, 2);
+        const blob = new Blob([data], { type: 'application/json' });
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const fileName = `drop-life-tracker-${timestamp}.json`;
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = fileName;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        setTimeout(() => URL.revokeObjectURL(url), 1000);
+        UI.notify('Data exported');
+      } catch (error) {
+        console.error('Data export failed:', error);
+        UI.notify('Export failed');
+      }
+    },
+
+    handleImport(file) {
+      try {
+        const reader = new FileReader();
+        reader.onload = (event) => {
+          try {
+            const raw = event.target?.result;
+            const payload = JSON.parse(raw);
+
+            if (!Store.validateImport(payload)) {
+              throw new Error('Invalid schema');
+            }
+
+            Store.merge(payload);
+            UI.setVisionFields(Store.state);
+            if (UI.elements.inputs.runValue) {
+              UI.elements.inputs.runValue.textContent = Store.state.run;
+            }
+            this.updateScores();
+            UI.notify('Data imported');
+          } catch (error) {
+            console.error('Data import failed:', error);
+            UI.notify('Import failed');
+          }
+        };
+
+        reader.onerror = () => {
+          UI.notify('Import failed');
+        };
+
+        reader.readAsText(file);
+      } catch (error) {
+        console.error('Failed to read import file:', error);
+        UI.notify('Import failed');
+      }
+    },
+
     bindEvents() {
       // Open overlays
       UI.elements.cards.forEach(card => {
@@ -429,6 +538,28 @@ document.addEventListener('DOMContentLoaded', () => {
           }
         });
       });
+
+      const { exportBtn, importBtn, importInput } = UI.elements.dataControls;
+      if (exportBtn) {
+        exportBtn.addEventListener('click', () => {
+          this.handleExport();
+        });
+      }
+
+      if (importBtn && importInput) {
+        importBtn.addEventListener('click', () => {
+          importInput.value = '';
+          importInput.click();
+        });
+
+        importInput.addEventListener('change', () => {
+          const [file] = importInput.files || [];
+          if (file) {
+            this.handleImport(file);
+          }
+          importInput.value = '';
+        });
+      }
     },
 
     mapVisionKey(key) {
@@ -458,8 +589,9 @@ document.addEventListener('DOMContentLoaded', () => {
       this.currentPage = page;
       this.updateNavState(page);
 
-      if (page === 'home') {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
+      const main = document.querySelector('.app-main');
+      if (main) {
+        main.scrollTo({ top: 0, behavior: 'smooth' });
       }
     },
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,6 +31,7 @@
   <!-- Developer pill (clickable) and small toast for dev messages -->
   <div class="dev-pill" id="dev-pill" title="Toggle developer mode">DEV</div>
   <div class="dev-toast" id="dev-toast" aria-live="polite"></div>
+  <div class="app-toast" id="app-toast" aria-live="polite" role="status"></div>
 
   <header class="app-header">
     <div class="app-header__top">
@@ -39,6 +40,11 @@
         <span class="install-button__icon" aria-hidden="true">➕</span>
         <span>Install App</span>
       </button>
+    </div>
+    <div class="data-controls" aria-label="Backup controls">
+      <button class="data-btn" id="export-data-btn" type="button">Export Data</button>
+      <button class="data-btn" id="import-data-btn" type="button">Import Data</button>
+      <input type="file" id="import-data-input" accept="application/json" hidden>
     </div>
     <!-- Screen reader announcements for score updates -->
     <div class="sr-announce" id="score-announcer" aria-live="polite" aria-atomic="true"></div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -40,6 +40,8 @@
   --spirit: #16a34a; /* Green */
 }
 
+html { height: 100%; }
+
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 body {
@@ -54,8 +56,7 @@ body {
   display: flex;
   flex-direction: column;
   overflow-x: hidden;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
+  overflow-y: hidden;
   touch-action: pan-y pinch-zoom;
   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
 }
@@ -80,9 +81,15 @@ body {
   flex: 1 1 auto;
   display: block;
   padding: 24px;
+  padding-bottom: calc(120px + env(safe-area-inset-bottom));
   background: radial-gradient(circle at top, var(--color-bg-gradient-start) 0%, var(--color-bg-gradient-end) 100%);
   width: 100%;
   min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  position: relative;
+  scroll-behavior: smooth;
+  touch-action: pan-y pinch-zoom;
 }
 
 /* === HEADER === */
@@ -92,6 +99,60 @@ body {
   align-items: center;
   gap: 12px;
   margin-bottom: 16px;
+}
+
+.data-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.data-btn {
+  flex: 1 1 120px;
+  min-width: 140px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: rgba(79, 138, 245, 0.12);
+  color: var(--color-text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  cursor: pointer;
+  transition: var(--transition-fast);
+  text-align: center;
+  -webkit-tap-highlight-color: rgba(79, 138, 245, 0.2);
+}
+
+.data-btn:hover,
+.data-btn:focus-visible {
+  border-color: var(--color-border-focus);
+  background: rgba(79, 138, 245, 0.2);
+  outline: none;
+}
+
+.app-toast {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: calc(96px + env(safe-area-inset-bottom));
+  background: rgba(28, 28, 33, 0.95);
+  color: var(--color-text-primary);
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-md);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 200;
+  font-size: 13px;
+}
+
+.app-toast.show {
+  opacity: 1;
+  transform: translate(-50%, -8px);
 }
 
 .date { font-size: 14px; color: var(--color-text-secondary); font-weight: 500; }

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,6 +1,7 @@
 // Service Worker for drop PWA
 
-const CACHE_NAME = 'drop-cache-v1';
+const APP_VERSION = '3.0.0';
+const CACHE_NAME = `drop-cache-v${APP_VERSION.replace(/\./g, '-')}`;
 const urlsToCache = [
   './',
   './index.html',
@@ -82,7 +83,10 @@ self.addEventListener('activate', event => {
             return caches.delete(cacheName);
           }
         })
-      ).then(() => self.clients.claim());
+      ).then(() => {
+        console.log(`Cache updated to v${APP_VERSION}`);
+        return self.clients.claim();
+      });
     })
   );
 });

--- a/docs/tests/visual.test.js
+++ b/docs/tests/visual.test.js
@@ -163,15 +163,67 @@ test.describe('Visual Regression Tests', () => {
     // Focus on home button
     const homeBtn = page.locator('[data-page="home"]');
     await homeBtn.focus();
-    
+
     // Wait for focus styles
     await page.waitForTimeout(100);
-    
+
     // Capture footer with focused element
     const footer = page.locator('.app-footer');
     await footer.screenshot({
       path: path.join(__dirname, 'screenshots', 'nav-focus.png')
     });
+  });
+
+  test('App shell scroll retains footer navigation access', async ({ page }) => {
+    const visionBtn = page.locator('[data-page="vision"]');
+    await visionBtn.click();
+    await page.waitForTimeout(300);
+
+    const scrollMetrics = await page.evaluate(() => {
+      const main = document.querySelector('.app-main');
+      if (!main) return { scrollHeight: 0, clientHeight: 0, scrollTop: 0 };
+      main.scrollTo({ top: main.scrollHeight, behavior: 'auto' });
+      return {
+        scrollHeight: main.scrollHeight,
+        clientHeight: main.clientHeight,
+        scrollTop: main.scrollTop
+      };
+    });
+
+    expect(scrollMetrics.scrollHeight).toBeGreaterThan(scrollMetrics.clientHeight);
+    expect(scrollMetrics.scrollTop).toBeGreaterThan(0);
+
+    const gratitudeBtn = page.locator('[data-page="gratitude"]');
+    await gratitudeBtn.click();
+    await expect(page.locator('[data-page="gratitude"].active')).toBeVisible();
+  });
+
+  test('Overlay scrolling does not lock the app shell', async ({ page }) => {
+    const fitnessCard = page.locator('[data-domain="fitness"].card');
+    await fitnessCard.click();
+    await page.waitForTimeout(400);
+
+    const overlayContent = page.locator('#fitness-overlay .overlay-content');
+    await expect(overlayContent).toHaveCSS('overflow-y', 'auto');
+
+    const closeBtn = page.locator('#fitness-overlay .close-btn');
+    await closeBtn.click();
+    await expect(page.locator('#fitness-overlay')).not.toHaveClass(/active/);
+
+    const visionBtn = page.locator('[data-page="vision"]');
+    await visionBtn.click();
+    await page.waitForTimeout(300);
+
+    const canScroll = await page.evaluate(() => {
+      const main = document.querySelector('.app-main');
+      if (!main) return false;
+      main.scrollTop = 0;
+      const initial = main.scrollTop;
+      main.scrollTo({ top: main.scrollHeight, behavior: 'auto' });
+      return main.scrollTop > initial;
+    });
+
+    expect(canScroll).toBeTruthy();
   });
 
   test('Progress bars on gratitude page', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add import/export controls for lifeTrackerData with schema validation and user-facing toast notifications
- adjust layout styling to isolate app-main scrolling, keep footer navigation tappable, and surface backup controls styling
- bump service worker cache naming to track v3.0.0 and log updates while retaining offline behavior
- extend Playwright regression suite to cover navigation scrolling and overlay interactions

## Testing
- npm run test:visual *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dff31544ec8323846ea821e5066a6a