### PR TITLE
feat: animate score meters for sprint 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Fonts:
 - **Sprint Summary**: `docs/SPRINT_SUMMARY.md`
 - **Verification Checklist**: `docs/VERIFICATION_CHECKLIST.md`
 - **Test Documentation**: `docs/tests/README.md`
+- **Sprint Backlog**: `docs/documentation/Sprints.md`
 
 ## 🌐 GitHub Pages Deployment
 

--- a/docs/VERIFICATION_CHECKLIST.md
+++ b/docs/VERIFICATION_CHECKLIST.md
@@ -5,7 +5,7 @@ Use this checklist to verify all sprint deliverables before merging to `main`.
 ## ✅ Accessibility Enhancements
 
 ### ARIA Attributes
-- [ ] Open DevTools → Elements → Inspect `.score-circle` elements
+- [ ] Open DevTools → Elements → Inspect `.score-meter` elements
 - [ ] Verify each has `role="meter"`, `aria-valuemin="0"`, `aria-valuemax="100"`, `aria-valuenow`
 - [ ] Verify each has `aria-label` (e.g., "Sleep score")
 
@@ -87,7 +87,7 @@ npm run test:visual
 - [ ] `gratitude-page-baseline.png`
 - [ ] `sleep-overlay-baseline.png`
 - [ ] `fitness-overlay-baseline.png`
-- [ ] `score-circles.png`
+- [ ] `score-meters.png`
 - [ ] `nav-focus.png`
 - [ ] `progress-bars.png`
 

--- a/docs/app.js
+++ b/docs/app.js
@@ -68,10 +68,26 @@ document.addEventListener('DOMContentLoaded', () => {
         progressBars: document.querySelectorAll('[data-progress-domain]')
       },
       scoreDisplays: {
-        sleep: { score: document.getElementById('sleep-score'), card: document.getElementById('sleep-card') },
-        fitness: { score: document.getElementById('fitness-score'), card: document.getElementById('fitness-card') },
-        mind: { score: document.getElementById('mind-score'), card: document.getElementById('mind-card') },
-        spirit: { score: document.getElementById('spirit-score'), card: document.getElementById('spirit-card') }
+        sleep: {
+          score: document.getElementById('sleep-score'),
+          card: document.getElementById('sleep-card'),
+          meter: document.querySelector('[data-domain-meter="sleep"]')
+        },
+        fitness: {
+          score: document.getElementById('fitness-score'),
+          card: document.getElementById('fitness-card'),
+          meter: document.querySelector('[data-domain-meter="fitness"]')
+        },
+        mind: {
+          score: document.getElementById('mind-score'),
+          card: document.getElementById('mind-card'),
+          meter: document.querySelector('[data-domain-meter="mind"]')
+        },
+        spirit: {
+          score: document.getElementById('spirit-score'),
+          card: document.getElementById('spirit-card'),
+          meter: document.querySelector('[data-domain-meter="spirit"]')
+        }
       },
       inputs: {
         wakeTime: document.getElementById('wake-time'),
@@ -83,31 +99,57 @@ document.addEventListener('DOMContentLoaded', () => {
     renderScores(scores) {
       const announcements = [];
       for (const domain in scores) {
-        const oldScore = this.elements.scoreDisplays[domain].score.textContent;
-        const newScore = scores[domain];
-        
-        // Update displayed scores
-        this.elements.scoreDisplays[domain].score.textContent = newScore;
-        this.elements.scoreDisplays[domain].card.textContent = newScore;
-        
-        // Update ARIA attributes on score circles
-        const scoreCircle = this.elements.scoreDisplays[domain].score.closest('.score-circle');
-        if (scoreCircle) {
-          scoreCircle.setAttribute('aria-valuenow', newScore);
+        const display = this.elements.scoreDisplays[domain];
+        if (!display) continue;
+
+        const previousValue = display.score ? display.score.textContent : null;
+        const numericScore = Number.isFinite(scores[domain]) ? scores[domain] : 0;
+        const clampedScore = Math.max(0, Math.min(100, Math.round(numericScore)));
+        const scoreText = String(clampedScore);
+
+        if (display.score) {
+          display.score.textContent = scoreText;
         }
-        
-        // Collect announcement if score changed
-        if (oldScore !== String(newScore)) {
-          announcements.push(`${domain.charAt(0).toUpperCase() + domain.slice(1)} score updated to ${newScore}`);
+        if (display.card) {
+          display.card.textContent = scoreText;
+        }
+        if (display.meter) {
+          display.meter.setAttribute('aria-valuenow', scoreText);
+          this.updateScoreRing(display.meter, clampedScore);
+        }
+
+        if (previousValue !== null && previousValue !== scoreText) {
+          announcements.push(`${domain.charAt(0).toUpperCase() + domain.slice(1)} score updated to ${scoreText}`);
         }
       }
-      
-      // Announce changes to screen readers (polite mode, non-disruptive)
+
       if (announcements.length > 0 && this.elements.scoreAnnouncer) {
         this.elements.scoreAnnouncer.textContent = announcements.join('. ');
       }
-      
+
       this.renderGratitude(scores);
+    },
+
+    updateScoreRing(meter, score) {
+      const arc = meter.querySelector('.score-ring__arc');
+      if (!arc) return;
+      const track = meter.querySelector('.score-ring__track');
+      const radius = (arc.r && arc.r.baseVal ? arc.r.baseVal.value : parseFloat(arc.getAttribute('r'))) || 52;
+      const circumference = 2 * Math.PI * radius;
+      const rootStyles = getComputedStyle(document.documentElement);
+      const gapValue = parseFloat(rootStyles.getPropertyValue('--score-ring-gap'));
+      const gapFraction = Number.isFinite(gapValue) ? Math.min(Math.max(gapValue, 0), 0.6) : 0.22;
+      const visibleLength = circumference * (1 - gapFraction);
+      const gapLength = circumference - visibleLength;
+      const dashArray = `${visibleLength.toFixed(2)} ${gapLength.toFixed(2)}`;
+      arc.style.strokeDasharray = dashArray;
+      if (track) {
+        track.style.strokeDasharray = dashArray;
+      }
+
+      const clamped = Math.max(0, Math.min(100, Number(score) || 0));
+      const dashOffset = visibleLength - (clamped / 100) * visibleLength;
+      arc.style.strokeDashoffset = `${dashOffset.toFixed(2)}`;
     },
 
     showLoading(show = true) {

--- a/docs/documentation/Sprints.md
+++ b/docs/documentation/Sprints.md
@@ -1,0 +1,27 @@
+# Sprint Backlog
+
+A running backlog of sprint goals and deliverables for the drop PWA.
+
+## Sprint 1 — Accessibility & Foundations (Complete)
+- Add ARIA meter roles and live announcements for domain scores.
+- Wire Esc key support and focus-visible outlines for overlays and navigation.
+- Introduce DOM (QUnit) and visual (Playwright) regression suites with developer tooling.
+- Publish documentation: sprint summary, verification checklist, and developer notes.
+
+## Sprint 2 — Score Rings & Visual Storytelling
+### Objectives
+- Reinstate the SVG score rings so progress is represented visually, not only numerically.
+- Pair each domain meter with its icon for stronger visual recognition.
+- Keep the experience accessible with proper meter semantics and announcer behaviour.
+
+### Scope & Tasks
+1. Replace the header score tiles with SVG-based meters that expose a bottom gap and central score value.
+2. Update the design system to style the new meters (ring sizing, colors, icon badge, transitions).
+3. Extend app logic so score updates drive the arc animation and aria-valuenow synchronisation.
+4. Refresh automated tests (QUnit + Playwright selectors) to target the new meter structure.
+
+### Acceptance Criteria
+- Each domain meter renders an SVG arc using the domain color with a visible gap at the bottom.
+- Scores update both the numeric label and arc stroke without visual jitter.
+- `aria-valuenow` values mirror the latest score and the announcer still reports changes.
+- Automated DOM tests acknowledge the new markup; visual tests reference the new selectors.

--- a/docs/index.html
+++ b/docs/index.html
@@ -43,30 +43,66 @@
     <!-- Screen reader announcements for score updates -->
     <div class="sr-announce" id="score-announcer" aria-live="polite" aria-atomic="true"></div>
     <div class="scores-grid">
-      <div class="score-item">
-        <div class="score-circle" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="99" aria-label="Sleep score">
-          <div class="score-value" id="sleep-score">99</div>
+      <article class="score-item" data-domain="sleep">
+        <div class="score-meter" data-domain-meter="sleep" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Sleep score">
+          <svg class="score-ring" viewBox="0 0 120 120" aria-hidden="true">
+            <circle class="score-ring__track" cx="60" cy="60" r="52"></circle>
+            <circle class="score-ring__arc" cx="60" cy="60" r="52"></circle>
+          </svg>
+          <div class="score-meter__center">
+            <span class="score-value" id="sleep-score">0</span>
+          </div>
+          <div class="score-meter__icon" aria-hidden="true">
+            <img src="icons/sleep.svg" alt="">
+          </div>
         </div>
         <div class="score-name">Sleep</div>
-      </div>
-      <div class="score-item">
-        <div class="score-circle" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="99" aria-label="Fitness score">
-          <div class="score-value" id="fitness-score">99</div>
+      </article>
+      <article class="score-item" data-domain="fitness">
+        <div class="score-meter" data-domain-meter="fitness" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Fitness score">
+          <svg class="score-ring" viewBox="0 0 120 120" aria-hidden="true">
+            <circle class="score-ring__track" cx="60" cy="60" r="52"></circle>
+            <circle class="score-ring__arc" cx="60" cy="60" r="52"></circle>
+          </svg>
+          <div class="score-meter__center">
+            <span class="score-value" id="fitness-score">0</span>
+          </div>
+          <div class="score-meter__icon" aria-hidden="true">
+            <img src="icons/fitness.svg" alt="">
+          </div>
         </div>
         <div class="score-name">Fitness</div>
-      </div>
-      <div class="score-item">
-        <div class="score-circle" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="99" aria-label="Mind score">
-          <div class="score-value" id="mind-score">99</div>
+      </article>
+      <article class="score-item" data-domain="mind">
+        <div class="score-meter" data-domain-meter="mind" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Mind score">
+          <svg class="score-ring" viewBox="0 0 120 120" aria-hidden="true">
+            <circle class="score-ring__track" cx="60" cy="60" r="52"></circle>
+            <circle class="score-ring__arc" cx="60" cy="60" r="52"></circle>
+          </svg>
+          <div class="score-meter__center">
+            <span class="score-value" id="mind-score">0</span>
+          </div>
+          <div class="score-meter__icon" aria-hidden="true">
+            <img src="icons/mind.svg" alt="">
+          </div>
         </div>
         <div class="score-name">Mind</div>
-      </div>
-      <div class="score-item">
-        <div class="score-circle" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="99" aria-label="Spirit score">
-          <div class="score-value" id="spirit-score">99</div>
+      </article>
+      <article class="score-item" data-domain="spirit">
+        <div class="score-meter" data-domain-meter="spirit" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Spirit score">
+          <svg class="score-ring" viewBox="0 0 120 120" aria-hidden="true">
+            <circle class="score-ring__track" cx="60" cy="60" r="52"></circle>
+            <circle class="score-ring__arc" cx="60" cy="60" r="52"></circle>
+          </svg>
+          <div class="score-meter__center">
+            <span class="score-value" id="spirit-score">0</span>
+          </div>
+          <div class="score-meter__icon" aria-hidden="true">
+            <img src="icons/spirit.svg" alt="">
+          </div>
         </div>
         <div class="score-name">Spirit</div>
-      </div>
+      </article>
     </div>
   </header>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -23,6 +23,10 @@
   --color-primary-gradient: linear-gradient(135deg, #3b82f6, #60a5fa);
   --color-shadow-primary: rgba(79, 138, 245, 0.2);
 
+  --score-ring-size: 96px;
+  --score-ring-stroke: 10px;
+  --score-ring-gap: 0.22;
+
   --shadow-sm: 0 2px 8px rgba(0,0,0,0.3);
   --shadow-md: 0 4px 12px rgba(0,0,0,0.4), inset 0 1px 0 var(--color-surface-inset);
   --shadow-lg: 0 8px 32px rgba(0,0,0,0.5);
@@ -127,46 +131,132 @@ body {
 .install-button__icon {
   font-size: 16px;
 }
-.scores-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; padding: 0 8px; }
-.score-item { 
-  text-align: center; 
+.scores-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 20px;
+  padding: 0 4px;
+}
+
+.score-item {
+  text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
+  padding-bottom: 28px;
+  position: relative;
 }
 
-.score-circle {
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
-  border: 3px solid var(--color-border);
+.score-meter {
+  position: relative;
+  width: var(--score-ring-size);
+  height: var(--score-ring-size);
   display: flex;
   align-items: center;
   justify-content: center;
-  position: relative;
-  background: rgba(0, 0, 0, 0.2);
+  border-radius: 50%;
+  background: linear-gradient(180deg, rgba(28, 28, 33, 0.95) 0%, rgba(10, 10, 14, 0.75) 100%);
+  box-shadow: 0 20px 38px rgba(0, 0, 0, 0.45);
+  overflow: visible;
 }
 
-.score-item:nth-child(1) .score-circle { border-color: var(--sleep); }
-.score-item:nth-child(2) .score-circle { border-color: var(--fitness); }
-.score-item:nth-child(3) .score-circle { border-color: var(--mind); }
-.score-item:nth-child(4) .score-circle { border-color: var(--spirit); }
+.score-ring {
+  width: 100%;
+  height: 100%;
+  transform: rotate(180deg);
+}
 
-.score-value { 
-  font-size: 32px; 
-  font-weight: 600; 
-  color: var(--color-text-primary); 
+.score-ring__track,
+.score-ring__arc {
+  fill: none;
+  stroke-width: var(--score-ring-stroke);
+}
+
+.score-ring__track {
+  stroke: rgba(240, 242, 245, 0.12);
+}
+
+.score-ring__arc {
+  stroke: var(--color-primary);
+  stroke-linecap: round;
+  transition: stroke-dashoffset var(--transition-slow), stroke 0.2s linear;
+}
+
+.score-item[data-domain="sleep"] .score-ring__arc { stroke: var(--sleep); }
+.score-item[data-domain="fitness"] .score-ring__arc { stroke: var(--fitness); }
+.score-item[data-domain="mind"] .score-ring__arc { stroke: var(--mind); }
+.score-item[data-domain="spirit"] .score-ring__arc { stroke: var(--spirit); }
+
+.score-item[data-domain="sleep"] .score-meter {
+  box-shadow: 0 20px 38px rgba(0, 0, 0, 0.45), 0 0 28px rgba(30, 144, 255, 0.22);
+}
+
+.score-item[data-domain="fitness"] .score-meter {
+  box-shadow: 0 20px 38px rgba(0, 0, 0, 0.45), 0 0 28px rgba(255, 59, 48, 0.22);
+}
+
+.score-item[data-domain="mind"] .score-meter {
+  box-shadow: 0 20px 38px rgba(0, 0, 0, 0.45), 0 0 28px rgba(124, 58, 237, 0.22);
+}
+
+.score-item[data-domain="spirit"] .score-meter {
+  box-shadow: 0 20px 38px rgba(0, 0, 0, 0.45), 0 0 28px rgba(22, 163, 74, 0.22);
+}
+
+.score-meter__center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -56%);
+  text-align: center;
+  pointer-events: none;
+}
+
+.score-value {
+  font-size: 32px;
+  font-weight: 600;
+  color: var(--color-text-primary);
   font-family: var(--font-mono);
   line-height: 1;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+}
+
+.score-meter__icon {
+  position: absolute;
+  bottom: -18px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: rgba(18, 18, 24, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.45);
+}
+
+.score-meter__icon img {
+  width: 22px;
+  height: 22px;
+  display: block;
 }
 
 .score-name {
   font-size: 11px;
   color: var(--color-text-tertiary);
-  font-weight: 500;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.55px;
+  margin-top: 16px;
+}
+
+@media (max-width: 360px) {
+  :root {
+    --score-ring-size: 88px;
+  }
 }
 
 .visually-hidden,

--- a/docs/tests/dom.test.js
+++ b/docs/tests/dom.test.js
@@ -33,30 +33,54 @@ QUnit.module('Domain Score Display', function(hooks) {
     // Create a minimal DOM structure for testing
     this.fixture = document.getElementById('qunit-fixture');
     this.fixture.innerHTML = `
-      <div class="score-item">
-        <div class="score-circle" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-label="Sleep score">
-          <div class="score-value" id="sleep-score">75</div>
+      <article class="score-item" data-domain="sleep">
+        <div class="score-meter" data-domain-meter="sleep" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-label="Sleep score">
+          <svg class="score-ring" viewBox="0 0 120 120">
+            <circle class="score-ring__track" cx="60" cy="60" r="52"></circle>
+            <circle class="score-ring__arc" cx="60" cy="60" r="52"></circle>
+          </svg>
+          <div class="score-meter__center">
+            <span class="score-value" id="sleep-score">75</span>
+          </div>
         </div>
         <div class="score-name">Sleep</div>
-      </div>
-      <div class="score-item">
-        <div class="score-circle" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="60" aria-label="Fitness score">
-          <div class="score-value" id="fitness-score">60</div>
+      </article>
+      <article class="score-item" data-domain="fitness">
+        <div class="score-meter" data-domain-meter="fitness" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="60" aria-label="Fitness score">
+          <svg class="score-ring" viewBox="0 0 120 120">
+            <circle class="score-ring__track" cx="60" cy="60" r="52"></circle>
+            <circle class="score-ring__arc" cx="60" cy="60" r="52"></circle>
+          </svg>
+          <div class="score-meter__center">
+            <span class="score-value" id="fitness-score">60</span>
+          </div>
         </div>
         <div class="score-name">Fitness</div>
-      </div>
-      <div class="score-item">
-        <div class="score-circle" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="80" aria-label="Mind score">
-          <div class="score-value" id="mind-score">80</div>
+      </article>
+      <article class="score-item" data-domain="mind">
+        <div class="score-meter" data-domain-meter="mind" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="80" aria-label="Mind score">
+          <svg class="score-ring" viewBox="0 0 120 120">
+            <circle class="score-ring__track" cx="60" cy="60" r="52"></circle>
+            <circle class="score-ring__arc" cx="60" cy="60" r="52"></circle>
+          </svg>
+          <div class="score-meter__center">
+            <span class="score-value" id="mind-score">80</span>
+          </div>
         </div>
         <div class="score-name">Mind</div>
-      </div>
-      <div class="score-item">
-        <div class="score-circle" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" aria-label="Spirit score">
-          <div class="score-value" id="spirit-score">50</div>
+      </article>
+      <article class="score-item" data-domain="spirit">
+        <div class="score-meter" data-domain-meter="spirit" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" aria-label="Spirit score">
+          <svg class="score-ring" viewBox="0 0 120 120">
+            <circle class="score-ring__track" cx="60" cy="60" r="52"></circle>
+            <circle class="score-ring__arc" cx="60" cy="60" r="52"></circle>
+          </svg>
+          <div class="score-meter__center">
+            <span class="score-value" id="spirit-score">50</span>
+          </div>
         </div>
         <div class="score-name">Spirit</div>
-      </div>
+      </article>
       <div class="card" id="sleep-card">75</div>
       <div class="card" id="fitness-card">60</div>
       <div class="card" id="mind-card">80</div>
@@ -71,15 +95,18 @@ QUnit.module('Domain Score Display', function(hooks) {
     assert.ok(document.getElementById('spirit-score'), 'Spirit score element exists');
   });
 
-  QUnit.test('Score circles have proper ARIA attributes', function(assert) {
-    const sleepCircle = document.querySelector('[aria-label="Sleep score"]');
-    assert.equal(sleepCircle.getAttribute('role'), 'meter', 'Sleep circle has meter role');
-    assert.equal(sleepCircle.getAttribute('aria-valuemin'), '0', 'Sleep circle has min value');
-    assert.equal(sleepCircle.getAttribute('aria-valuemax'), '100', 'Sleep circle has max value');
-    assert.equal(sleepCircle.getAttribute('aria-valuenow'), '75', 'Sleep circle has current value');
-    
-    const fitnessCircle = document.querySelector('[aria-label="Fitness score"]');
-    assert.ok(fitnessCircle.hasAttribute('aria-valuenow'), 'Fitness circle has aria-valuenow');
+  QUnit.test('Score meters expose ARIA attributes and arcs', function(assert) {
+    const sleepMeter = document.querySelector('[data-domain-meter="sleep"]');
+    assert.equal(sleepMeter.getAttribute('role'), 'meter', 'Sleep meter has meter role');
+    assert.equal(sleepMeter.getAttribute('aria-valuemin'), '0', 'Sleep meter has min value');
+    assert.equal(sleepMeter.getAttribute('aria-valuemax'), '100', 'Sleep meter has max value');
+    assert.equal(sleepMeter.getAttribute('aria-valuenow'), '75', 'Sleep meter has current value');
+
+    const sleepArc = sleepMeter.querySelector('.score-ring__arc');
+    assert.ok(sleepArc, 'Sleep meter renders a progress arc');
+
+    const fitnessMeter = document.querySelector('[data-domain-meter="fitness"]');
+    assert.ok(fitnessMeter.hasAttribute('aria-valuenow'), 'Fitness meter has aria-valuenow');
   });
 
   QUnit.test('Score values are numeric', function(assert) {

--- a/docs/tests/visual.test.js
+++ b/docs/tests/visual.test.js
@@ -144,18 +144,18 @@ test.describe('Visual Regression Tests', () => {
     });
   });
 
-  test('Score circles with different values', async ({ page }) => {
+  test('Score meters with different values', async ({ page }) => {
     // This test verifies visual consistency of score rendering
     const scoresGrid = page.locator('.scores-grid');
     await expect(scoresGrid).toBeVisible();
-    
-    // Check all score circles are rendered
-    const scoreCircles = page.locator('.score-circle');
-    await expect(scoreCircles).toHaveCount(4);
-    
+
+    // Check all score meters are rendered
+    const scoreMeters = page.locator('[data-domain-meter]');
+    await expect(scoreMeters).toHaveCount(4);
+
     // Take focused screenshot of scores
     await scoresGrid.screenshot({
-      path: path.join(__dirname, 'screenshots', 'score-circles.png')
+      path: path.join(__dirname, 'screenshots', 'score-meters.png')
     });
   });
 


### PR DESCRIPTION
## Summary
- replace the header score tiles with SVG-based meters and domain icon badges
- update score rendering logic and styles so meter arcs animate and aria values stay in sync
- document the sprint backlog and refresh automated test selectors plus checklist references

## Testing
- npm run test:dom

------
https://chatgpt.com/codex/tasks/task_e_68dff5cf7e2c8323aabcdc0b5396431a