### PR TITLE
Fix local date reset and remove dev controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/node_modules/

--- a/docs/app.js
+++ b/docs/app.js
@@ -32,7 +32,11 @@ document.addEventListener('DOMContentLoaded', () => {
     },
 
     getToday() {
-      return new Date().toISOString().split('T')[0];
+      const now = new Date();
+      const year = now.getFullYear();
+      const month = String(now.getMonth() + 1).padStart(2, '0');
+      const day = String(now.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
     },
 
     resetDailyData() {
@@ -320,6 +324,22 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     },
 
+    removeDevElements() {
+      if (DEV_MODE) return;
+
+      const devElements = [
+        this.elements.devPill,
+        document.getElementById('dev-loader-toggle'),
+        this.elements.devToast
+      ];
+
+      devElements.forEach(el => {
+        if (el && el.parentElement) {
+          el.parentElement.removeChild(el);
+        }
+      });
+    },
+
     toast(msg, ms = 1500) {
       if (!DEV_MODE) return;
       const t = this.elements.devToast;
@@ -525,6 +545,7 @@ document.addEventListener('DOMContentLoaded', () => {
     init() {
       Store.init();
       UI.initDate();
+      UI.removeDevElements();
       UI.setVisionFields(Store.state);
       this.syncDailyUI();
 


### PR DESCRIPTION
## Summary
- ensure the store's current-day detection uses the local timezone so daily inputs start fresh each day
- strip developer-only UI elements when not in dev mode to remove the lingering refresh control
- ignore the docs/node_modules directory from version control

## Testing
- npm test --prefix docs

------
https://chatgpt.com/codex/tasks/task_e_68e19a81098c832391bafc7e920f5cfb