### PR TITLE
Update PWA manifest metadata for install readiness

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,6 +1,8 @@
 {
+  "id": "./",
   "name": "drop",
   "short_name": "drop",
+  "lang": "en",
   "description": "Track your sleep, fitness, mind, and spirit daily.",
   "start_url": "./?source=pwa",
   "scope": "./",
@@ -8,17 +10,24 @@
   "orientation": "portrait",
   "background_color": "#0B0B0F",
   "theme_color": "#1C1C21",
+  "categories": [
+    "health",
+    "productivity",
+    "lifestyle"
+  ],
+  "prefer_related_applications": false,
   "icons": [
     {
       "src": "icons/drop_rounded_app_icon.png",
-      "sizes": "1024x1024",
+      "sizes": "720x720",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
       "src": "icons/drop_rounded.png",
-      "sizes": "563x564",
-      "type": "image/png"
+      "sizes": "500x500",
+      "type": "image/png",
+      "purpose": "any"
     },
     {
       "src": "icons/drop_icon.svg",

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -8,7 +8,7 @@ const urlsToCache = [
   './styles.css',
   './app.js',
   './manifest.json',
-  './icons/drop_app_icon.png',
+  './icons/drop_rounded_app_icon.png',
   './icons/drop_rounded.png',
   './icons/drop_icon.svg',
   './icons/vision.svg',


### PR DESCRIPTION
## Summary
- enrich the PWA manifest with an app id, locale, categories, and updated icon metadata for the new rounded app icon
- refresh the service worker pre-cache list to include the renamed app icon asset so install prompts can find it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5884265c8832392fcb0167d726655