### PR TITLE
Add automatic local backup support

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -550,6 +550,13 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     Store.init();
+    if (typeof Backup !== 'undefined' && typeof Backup.init === 'function') {
+      try {
+        await Backup.init({ getState: () => Store.state });
+      } catch (error) {
+        console.error('Backup initialization failed:', error);
+      }
+    }
     App.init();
     App.setupDevPill();
   })();

--- a/docs/backup.js
+++ b/docs/backup.js
@@ -1,0 +1,496 @@
+/**
+ * ===========================
+ * BACKUP MODULE
+ * ===========================
+ *
+ * Handles automatic backups of the drop app state to a user-selected folder
+ * on the local device using the File System Access API.
+ *
+ * Responsibilities:
+ * - Persist the user's chosen directory handle using IndexedDB
+ * - Throttle automatic backups after Store.save() calls
+ * - Provide manual "Backup Now" support from the settings menu
+ * - Keep the backup folder tidy by rotating daily snapshots
+ * - Avoid redundant writes by hashing the payload before saving
+ */
+
+const Backup = {
+  DB_NAME: 'drop-backup',
+  STORE_NAME: 'handles',
+  HANDLE_KEY: 'local-backup-dir',
+  METADATA_KEY: 'drop-backup-metadata',
+  AUTO_DELAY_MS: 4000,
+  MAX_DAILY_FILES: 14,
+  MAX_ENTRY_SNAPSHOTS: 120,
+
+  dirHandle: null,
+  pendingTimer: null,
+  busy: false,
+  supported: false,
+  ready: false,
+  metadata: {
+    lastBackupISO: '',
+    lastDailyISO: '',
+    lastHash: ''
+  },
+  getState: null,
+
+  async init({ getState } = {}) {
+    this.getState = typeof getState === 'function'
+      ? getState
+      : () => (typeof Store !== 'undefined' ? Store.state : {});
+
+    this.supported = this.checkSupport();
+    this.loadMetadata();
+
+    if (!this.supported) {
+      this.updateUI({
+        statusText: 'Local folder backups are not available on this device.',
+        unsupported: true,
+        ready: false
+      });
+      return;
+    }
+
+    try {
+      this.dirHandle = await this.loadHandle();
+    } catch (error) {
+      console.error('Backup: Failed to load stored directory handle', error);
+      this.dirHandle = null;
+    }
+
+    if (!this.dirHandle) {
+      this.updateUI({ statusText: 'Choose a folder to store automatic backups.' });
+      return;
+    }
+
+    const hasPermission = await this.ensurePermission(this.dirHandle, 'readwrite', false);
+
+    if (!hasPermission) {
+      this.updateUI({
+        statusText: 'Allow folder access to resume automatic backups.',
+        ready: false,
+        needsPermission: true
+      });
+      return;
+    }
+
+    this.ready = true;
+    this.updateUI({
+      statusText: this.describeCurrentStatus(),
+      ready: true
+    });
+    this.scheduleBackup('startup');
+  },
+
+  checkSupport() {
+    return typeof window !== 'undefined'
+      && 'showDirectoryPicker' in window
+      && typeof indexedDB !== 'undefined';
+  },
+
+  loadMetadata() {
+    try {
+      const raw = localStorage.getItem(this.METADATA_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        this.metadata = { ...this.metadata, ...parsed };
+      }
+    } catch (error) {
+      console.warn('Backup: Failed to read metadata', error);
+    }
+  },
+
+  saveMetadata() {
+    try {
+      localStorage.setItem(this.METADATA_KEY, JSON.stringify(this.metadata));
+    } catch (error) {
+      console.warn('Backup: Failed to persist metadata', error);
+    }
+  },
+
+  async openDb() {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(this.DB_NAME, 1);
+      request.onerror = () => reject(request.error);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(this.STORE_NAME)) {
+          db.createObjectStore(this.STORE_NAME);
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+    });
+  },
+
+  async loadHandle() {
+    const db = await this.openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(this.STORE_NAME, 'readonly');
+      const store = tx.objectStore(this.STORE_NAME);
+      const req = store.get(this.HANDLE_KEY);
+      req.onsuccess = () => {
+        resolve(req.result || null);
+        db.close();
+      };
+      req.onerror = () => {
+        reject(req.error);
+        db.close();
+      };
+    });
+  },
+
+  async persistHandle(handle) {
+    const db = await this.openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(this.STORE_NAME, 'readwrite');
+      const store = tx.objectStore(this.STORE_NAME);
+      const req = store.put(handle, this.HANDLE_KEY);
+      req.onsuccess = () => {
+        resolve();
+        db.close();
+      };
+      req.onerror = () => {
+        reject(req.error);
+        db.close();
+      };
+    });
+  },
+
+  async ensurePermission(handle, mode = 'readwrite', request = false) {
+    if (!handle || typeof handle.queryPermission !== 'function') {
+      return true;
+    }
+
+    const options = { mode };
+    try {
+      const status = await handle.queryPermission(options);
+      if (status === 'granted') {
+        return true;
+      }
+      if (!request) {
+        return false;
+      }
+      if (typeof handle.requestPermission === 'function') {
+        const result = await handle.requestPermission(options);
+        return result === 'granted';
+      }
+    } catch (error) {
+      console.warn('Backup: Permission request failed', error);
+    }
+    return false;
+  },
+
+  describeCurrentStatus() {
+    if (!this.dirHandle) {
+      return 'Choose a folder to store automatic backups.';
+    }
+    if (this.metadata.lastBackupISO) {
+      return `Last backup: ${this.formatTimestamp(this.metadata.lastBackupISO)}`;
+    }
+    return 'Backup folder linked. Backups run automatically after changes.';
+  },
+
+  updateUI({ statusText = '', ready, needsPermission = false, unsupported = false, busy = this.busy } = {}) {
+    if (typeof UI === 'undefined' || typeof UI.setBackupState !== 'function') {
+      return;
+    }
+
+    const resolvedReady = typeof ready === 'boolean'
+      ? ready
+      : Boolean(this.dirHandle && !needsPermission && !unsupported);
+
+    this.ready = resolvedReady;
+    UI.setBackupState({
+      statusText: statusText || this.describeCurrentStatus(),
+      ready: resolvedReady,
+      needsPermission,
+      unsupported,
+      busy
+    });
+  },
+
+  async chooseDirectory() {
+    if (!this.supported) {
+      if (typeof UI !== 'undefined') {
+        UI.notify?.('Local folder backups are not supported on this device.');
+      }
+      this.updateUI({
+        statusText: 'Local folder backups are not available on this device.',
+        unsupported: true,
+        ready: false
+      });
+      return;
+    }
+
+    try {
+      const rootHandle = await window.showDirectoryPicker({ id: 'drop-backups', mode: 'readwrite' });
+      const dirHandle = await rootHandle.getDirectoryHandle('drop-backups', { create: true });
+      const granted = await this.ensurePermission(dirHandle, 'readwrite', true);
+
+      if (!granted) {
+        throw new Error('permission-denied');
+      }
+
+      this.dirHandle = dirHandle;
+      await this.persistHandle(dirHandle);
+      this.metadata.lastBackupISO = '';
+      this.metadata.lastDailyISO = '';
+      this.metadata.lastHash = '';
+      this.saveMetadata();
+      this.ready = true;
+      this.updateUI({ statusText: 'Backup folder connected. Creating first backup…', ready: true, busy: true });
+      await this.performBackup('setup');
+      if (typeof UI !== 'undefined' && typeof UI.notify === 'function') {
+        UI.notify('Backup folder connected');
+      }
+    } catch (error) {
+      if (error?.name === 'AbortError') {
+        this.updateUI({ statusText: this.describeCurrentStatus(), ready: this.ready });
+        return;
+      }
+      console.error('Backup: Failed to configure folder', error);
+      if (error?.message === 'permission-denied') {
+        if (typeof UI !== 'undefined' && typeof UI.notify === 'function') {
+          UI.notify('Permission required to write backups to the selected folder.');
+        }
+        this.updateUI({
+          statusText: 'Permission required. Choose the folder again and allow access.',
+          ready: false,
+          needsPermission: true
+        });
+      } else {
+        if (typeof UI !== 'undefined' && typeof UI.notify === 'function') {
+          UI.notify('Unable to configure backup folder. Try a different location.');
+        }
+        this.updateUI({
+          statusText: 'Unable to access folder. Choose a different location.',
+          ready: false,
+          needsPermission: true
+        });
+      }
+    }
+  },
+
+  async manualBackup() {
+    if (!this.supported) {
+      if (typeof UI !== 'undefined' && typeof UI.notify === 'function') {
+        UI.notify('Local folder backups are not supported on this device.');
+      }
+      return;
+    }
+    if (!this.dirHandle) {
+      if (typeof UI !== 'undefined' && typeof UI.notify === 'function') {
+        UI.notify('Choose a backup folder first.');
+      }
+      this.updateUI({ statusText: 'Choose a folder to store automatic backups.', ready: false });
+      return;
+    }
+    await this.performBackup('manual');
+  },
+
+  handleStoreSave() {
+    if (!this.supported || !this.dirHandle || this.busy) {
+      return;
+    }
+    this.scheduleBackup('auto');
+  },
+
+  scheduleBackup(reason = 'auto') {
+    if (!this.ready || !this.dirHandle) {
+      return;
+    }
+
+    if (reason === 'manual') {
+      this.performBackup('manual');
+      return;
+    }
+
+    if (this.pendingTimer) {
+      clearTimeout(this.pendingTimer);
+    }
+
+    const delay = reason === 'startup' ? 1500 : this.AUTO_DELAY_MS;
+    this.pendingTimer = setTimeout(() => {
+      this.pendingTimer = null;
+      this.performBackup('auto');
+    }, delay);
+  },
+
+  async performBackup(reason = 'auto') {
+    if (!this.dirHandle || this.busy) {
+      return false;
+    }
+
+    const hasPermission = await this.ensurePermission(this.dirHandle, 'readwrite', reason !== 'auto');
+    if (!hasPermission) {
+      this.updateUI({
+        statusText: 'Allow folder access to resume automatic backups.',
+        ready: false,
+        needsPermission: true
+      });
+      return false;
+    }
+
+    this.busy = true;
+    this.updateUI({ statusText: 'Backing up…', ready: true, busy: true });
+
+    let uiState = {
+      statusText: this.describeCurrentStatus(),
+      ready: true,
+      needsPermission: false
+    };
+
+    try {
+      const payload = await this.buildPayload();
+      const hash = await this.hashString(payload);
+
+      if (hash === this.metadata.lastHash && reason !== 'manual') {
+        this.metadata.lastBackupISO = new Date().toISOString();
+        this.saveMetadata();
+        uiState.statusText = `${this.describeCurrentStatus()} (up to date)`;
+        return true;
+      }
+
+      await this.writeFile(this.dirHandle, 'drop-backup-latest.json', payload);
+
+      const today = new Date().toISOString().slice(0, 10);
+      const dailyName = `drop-backup-${today}.json`;
+      await this.writeFile(this.dirHandle, dailyName, payload);
+      this.metadata.lastDailyISO = today;
+      await this.pruneOldBackups(this.dirHandle);
+
+      this.metadata.lastBackupISO = new Date().toISOString();
+      this.metadata.lastHash = hash;
+      this.saveMetadata();
+
+      uiState.statusText = this.describeCurrentStatus();
+      if (reason === 'manual' && typeof UI !== 'undefined' && typeof UI.notify === 'function') {
+        UI.notify('Backup saved');
+      }
+      return true;
+    } catch (error) {
+      console.error('Backup: Failed to write backup file', error);
+      uiState = {
+        statusText: 'Backup failed. Reconnect the folder to continue.',
+        ready: false,
+        needsPermission: true
+      };
+      if (typeof UI !== 'undefined' && typeof UI.notify === 'function') {
+        UI.notify('Backup failed. Check folder access and try again.');
+      }
+      return false;
+    } finally {
+      this.busy = false;
+      this.updateUI({ ...uiState, busy: false });
+    }
+  },
+
+  async buildPayload() {
+    const rawState = this.getState ? this.getState() : {};
+    const safeState = JSON.parse(JSON.stringify(rawState || {}));
+
+    if (safeState && typeof safeState === 'object' && safeState.entries && typeof safeState.entries === 'object') {
+      const dates = Object.keys(safeState.entries).sort();
+      if (dates.length > this.MAX_ENTRY_SNAPSHOTS) {
+        const trimmed = dates.length - this.MAX_ENTRY_SNAPSHOTS;
+        const keepDates = dates.slice(-this.MAX_ENTRY_SNAPSHOTS);
+        const pruned = {};
+        keepDates.forEach(date => {
+          pruned[date] = safeState.entries[date];
+        });
+        safeState.entries = pruned;
+        safeState._backupMeta = {
+          ...(safeState._backupMeta || {}),
+          trimmedEntries: trimmed
+        };
+      }
+    }
+
+    const payload = {
+      version: 1,
+      source: 'drop-life-tracker',
+      exportedAt: new Date().toISOString(),
+      metadata: {
+        entriesRetained: safeState.entries ? Object.keys(safeState.entries).length : 0,
+        lastEntryDate: safeState.lastEntryDate || null
+      },
+      state: safeState
+    };
+
+    return JSON.stringify(payload, null, 2);
+  },
+
+  async writeFile(dirHandle, name, contents) {
+    const fileHandle = await dirHandle.getFileHandle(name, { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(contents);
+    await writable.close();
+  },
+
+  async pruneOldBackups(dirHandle) {
+    const backups = [];
+    try {
+      for await (const [name] of dirHandle.entries()) {
+        if (/^drop-backup-\d{4}-\d{2}-\d{2}\.json$/u.test(name)) {
+          backups.push(name);
+        }
+      }
+    } catch (error) {
+      console.warn('Backup: Unable to enumerate backup directory', error);
+      return;
+    }
+
+    backups.sort();
+    while (backups.length > this.MAX_DAILY_FILES) {
+      const oldest = backups.shift();
+      try {
+        await dirHandle.removeEntry(oldest);
+      } catch (error) {
+        console.warn('Backup: Failed to remove old snapshot', oldest, error);
+        break;
+      }
+    }
+  },
+
+  async hashString(input) {
+    if (typeof window === 'undefined' || !window.crypto || !window.crypto.subtle) {
+      let hash = 0;
+      for (let i = 0; i < input.length; i += 1) {
+        hash = (hash << 5) - hash + input.charCodeAt(i);
+        hash |= 0;
+      }
+      return String(hash);
+    }
+    const encoder = new TextEncoder();
+    const data = encoder.encode(input);
+    const digest = await window.crypto.subtle.digest('SHA-256', data);
+    return Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
+  },
+
+  formatTimestamp(isoString) {
+    if (!isoString) return '';
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) {
+      return '';
+    }
+    const now = new Date();
+    const sameDay = date.toDateString() === now.toDateString();
+    const yesterday = new Date(now);
+    yesterday.setDate(now.getDate() - 1);
+    const timeFormatter = new Intl.DateTimeFormat(undefined, { timeStyle: 'short' });
+
+    if (sameDay) {
+      return `Today at ${timeFormatter.format(date)}`;
+    }
+    if (date.toDateString() === yesterday.toDateString()) {
+      return `Yesterday at ${timeFormatter.format(date)}`;
+    }
+    const formatter = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+    return formatter.format(date);
+  }
+};
+
+if (typeof window !== 'undefined') {
+  window.Backup = Backup;
+}

--- a/docs/icons/folder_sync.svg
+++ b/docs/icons/folder_sync.svg
@@ -1,0 +1,7 @@
+<svg width="64" height="64" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 7.5A2.5 2.5 0 0 1 5.5 5H9l2 2h7.5A2.5 2.5 0 0 1 21 9.5v8A2.5 2.5 0 0 1 18.5 20h-13A2.5 2.5 0 0 1 3 17.5z"/>
+  <path d="M9.5 14.5a2.5 2.5 0 0 1 2.5-2.5H13"/>
+  <path d="M15 10.5l-2 2 2 2"/>
+  <path d="M14.5 13.5a2.5 2.5 0 0 1-2.5 2.5H11"/>
+  <path d="M9 17.5l2-2-2-2"/>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -919,6 +919,15 @@
         </section>
         <section class="settings-section">
           <h3 class="settings-section__title">Data Management</h3>
+          <button class="settings-btn" id="settings-backup-setup-btn" type="button">
+            <span class="settings-btn__icon icon-folder-sync" aria-hidden="true"></span>
+            <span>Configure Local Backup</span>
+          </button>
+          <button class="settings-btn" id="settings-backup-now-btn" type="button" disabled>
+            <span class="settings-btn__icon icon-database-export" aria-hidden="true"></span>
+            <span>Backup Now</span>
+          </button>
+          <p class="settings-helper-text" id="settings-backup-status" role="status" aria-live="polite">Choose a folder to enable automatic backups.</p>
           <button class="settings-btn" id="settings-export-btn" type="button">
             <span class="settings-btn__icon icon-database-export" aria-hidden="true"></span>
             <span>Export Data</span>
@@ -951,6 +960,7 @@
   <script src="store.js"></script>
   <script src="scoring.js"></script>
   <script src="ui.js"></script>
+  <script src="backup.js"></script>
   <script src="install.js"></script>
   <script src="analytics.js"></script>
   <script src="app.js"></script>

--- a/docs/store.js
+++ b/docs/store.js
@@ -295,6 +295,9 @@ const Store = {
 
   save() {
     localStorage.setItem(this.DB_KEY, JSON.stringify(this.state));
+    if (typeof Backup !== 'undefined' && typeof Backup.handleStoreSave === 'function') {
+      Backup.handleStoreSave();
+    }
   },
 
   update(key, value) {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -22,6 +22,10 @@
   --color-primary: #4F8AF5;
   --color-primary-gradient: linear-gradient(135deg, #3b82f6, #60a5fa);
   --color-shadow-primary: rgba(79, 138, 245, 0.2);
+  --color-success: #4ade80;
+  --color-warning: #facc15;
+  --color-danger: #f87171;
+  --color-info: #38bdf8;
 
   /* === HEADER SIZE CONTROLS === */
   /* Adjust --header-scale to resize the entire header/scores section (0.7 = 70%, 1.0 = 100%, etc.) */
@@ -2630,6 +2634,20 @@ body {
   touch-action: manipulation;
 }
 
+.settings-btn:disabled,
+.settings-btn[aria-disabled="true"] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.settings-btn.is-busy::after {
+  content: '…';
+  margin-left: auto;
+  font-size: 20px;
+  opacity: 0.6;
+}
+
 .settings-btn:hover {
   background: var(--color-surface-2);
   border-color: var(--color-border-hover);
@@ -2674,6 +2692,27 @@ body {
 .settings-btn__icon {
   font-size: 20px;
   line-height: 1;
+}
+
+.settings-helper-text {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  margin: 0 0 16px 44px;
+  line-height: 1.4;
+  max-width: 320px;
+}
+
+.settings-helper-text[data-state="ready"] {
+  color: var(--color-success);
+}
+
+.settings-helper-text[data-state="permission"] {
+  color: var(--color-warning);
+}
+
+.settings-helper-text[data-state="unsupported"],
+.settings-helper-text[data-state="error"] {
+  color: var(--color-danger);
 }
 
 /* SVG Icon backgrounds for settings buttons */
@@ -2723,6 +2762,17 @@ body {
 
 .icon-install-app {
   background-image: url('icons/install_app.svg');
+  background-size: 20px 20px;
+  background-repeat: no-repeat;
+  background-position: center;
+  width: 20px;
+  height: 20px;
+  display: inline-block;
+  filter: brightness(0) invert(1);
+}
+
+.icon-folder-sync {
+  background-image: url('icons/folder_sync.svg');
   background-size: 20px 20px;
   background-repeat: no-repeat;
   background-position: center;

--- a/docs/ui.js
+++ b/docs/ui.js
@@ -29,6 +29,9 @@ const UI = {
       closeBtn: document.getElementById('settings-close-btn'),
       backdrop: document.getElementById('settings-backdrop'),
       installBtn: document.getElementById('settings-install-btn'),
+      backupSetupBtn: document.getElementById('settings-backup-setup-btn'),
+      backupNowBtn: document.getElementById('settings-backup-now-btn'),
+      backupStatus: document.getElementById('settings-backup-status'),
       exportBtn: document.getElementById('settings-export-btn'),
       importBtn: document.getElementById('settings-import-btn'),
       importInput: document.getElementById('settings-import-input'),
@@ -273,6 +276,37 @@ const UI = {
     this.toastTimer = setTimeout(() => {
       toast.classList.remove('show');
     }, ms);
+  },
+
+  setBackupState({ statusText = '', ready, needsPermission = false, unsupported = false, busy = false } = {}) {
+    const { backupStatus, backupNowBtn, backupSetupBtn } = this.elements.settingsMenu;
+    const resolvedReady = typeof ready === 'boolean' ? ready : Boolean(!unsupported && !needsPermission);
+
+    if (backupStatus) {
+      backupStatus.textContent = statusText;
+      if (unsupported) {
+        backupStatus.dataset.state = 'unsupported';
+      } else if (needsPermission) {
+        backupStatus.dataset.state = 'permission';
+      } else if (resolvedReady) {
+        backupStatus.dataset.state = 'ready';
+      } else {
+        backupStatus.dataset.state = 'idle';
+      }
+    }
+
+    if (backupNowBtn) {
+      const disabled = !resolvedReady || busy;
+      backupNowBtn.disabled = disabled;
+      backupNowBtn.setAttribute('aria-disabled', String(disabled));
+      backupNowBtn.classList.toggle('is-busy', Boolean(busy));
+    }
+
+    if (backupSetupBtn) {
+      const disabled = Boolean(busy);
+      backupSetupBtn.disabled = disabled;
+      backupSetupBtn.setAttribute('aria-disabled', String(disabled));
+    }
   },
 
   renderSkillChips() {
@@ -1411,7 +1445,18 @@ const UI = {
   },
 
   bindSettingsMenu() {
-    const { menu, openBtn, closeBtn, backdrop, exportBtn, importBtn, importInput, clearBtn } = UI.elements.settingsMenu;
+    const {
+      menu,
+      openBtn,
+      closeBtn,
+      backdrop,
+      exportBtn,
+      importBtn,
+      importInput,
+      clearBtn,
+      backupSetupBtn,
+      backupNowBtn
+    } = UI.elements.settingsMenu;
     
     if (!menu || !openBtn) return;
 
@@ -1447,6 +1492,34 @@ const UI = {
       exportBtn.addEventListener('click', () => {
         Store.handleExport();
         closeSettings();
+      });
+    }
+
+    if (backupSetupBtn) {
+      backupSetupBtn.addEventListener('click', async () => {
+        if (typeof Backup === 'undefined' || typeof Backup.chooseDirectory !== 'function') {
+          UI.notify('Local folder backups are not supported on this device.');
+          return;
+        }
+        try {
+          await Backup.chooseDirectory();
+        } catch (error) {
+          console.error('Backup setup failed:', error);
+        }
+      });
+    }
+
+    if (backupNowBtn) {
+      backupNowBtn.addEventListener('click', async () => {
+        if (typeof Backup === 'undefined' || typeof Backup.manualBackup !== 'function') {
+          UI.notify('Local folder backups are not supported on this device.');
+          return;
+        }
+        try {
+          await Backup.manualBackup();
+        } catch (error) {
+          console.error('Manual backup failed:', error);
+        }
       });
     }
 


### PR DESCRIPTION
## Summary
- add a File System Access-based backup module that persists the chosen folder, throttles automatic writes, and trims stored history
- expose backup configuration and manual trigger controls in the settings menu with live status feedback
- update styling, icons, and store/app initialization to hook the backup workflow into existing persistence

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e9c3c36cd88323aaac16fe13f58d06