### PR TITLE
Refactor store for debounced saves and computed history

### DIFF
--- a/docs/analytics.js
+++ b/docs/analytics.js
@@ -6,7 +6,7 @@ const Analytics = {
    * Calculates streaks for each domain based on recent history.
    */
   calculateStreaks() {
-    const history = Array.isArray(Store.state.history) ? [...Store.state.history] : [];
+    const history = typeof Store.getHistory === 'function' ? Store.getHistory(7) : [];
     const recent = history.slice(-7);
     const domains = ['sleep', 'fitness', 'mind', 'spirit'];
     const streaks = {};
@@ -31,7 +31,11 @@ const Analytics = {
   getWeeklyData() {
     const domains = ['sleep', 'fitness', 'mind', 'spirit'];
     const formatDomain = (domain) => domain.charAt(0).toUpperCase() + domain.slice(1);
-    const history = Array.isArray(Store.state.history) ? [...Store.state.history] : [];
+    const history = typeof Store.getHistory === 'function' ? Store.getHistory(30, { includeArchived: true }) : [];
+    const historyMap = history.reduce((acc, entry) => {
+      acc[entry.date] = entry;
+      return acc;
+    }, {});
     const today = Store.getToday();
     const dayNames = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
     const fullDayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -50,7 +54,7 @@ const Analytics = {
       d.setDate(d.getDate() - daysSinceMonday + i);
       const dateKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
       const dayIndex = d.getDay();
-      const entry = history.find(e => e.date === dateKey) || { date: dateKey, scores: {} };
+      const entry = historyMap[dateKey] || { date: dateKey, scores: {} };
 
       last7Days.push({
         dayLabel: dayNames[dayIndex],

--- a/docs/documentation/DATA_OVERHAUL_PLAN.md
+++ b/docs/documentation/DATA_OVERHAUL_PLAN.md
@@ -1,0 +1,73 @@
+# Drop PWA Data Overhaul Plan
+
+## Overview
+- **Goal:** Improve persistence performance, reduce redundancy, and create a future-proof storage layer.
+- **Timeline:** Approximately two sprints (7–10 days total).
+
+## Phase 1: Core Refactor (Sprint 1)
+### Objective
+Optimize the existing `store.js` implementation while continuing to use `localStorage` to avoid breaking changes.
+
+### Key Actions & Expected Outcomes
+- **Storage model:** Remove `dailyTimestamps`; derive timestamps from entries (10–15% storage reduction).
+- **History:** Compute history on demand with `getHistory(days)` (30–40% storage reduction).
+- **Save logic:** Introduce debounced saves (300–500 ms interval) to reduce write operations by 80%.
+- **Error handling:** Catch `QuotaExceededError` and archive or warn users to prevent data loss.
+- **Export:** Sanitize export payload so it includes only `meta` (settings, schema) and `entries` for cleaner JSON exports.
+- **Data schema versioning:** Add `_version` (currently `2`) and `_schemaDate` fields to enable future migrations.
+
+### Deliverables
+- Refactored `store.js` incorporating debounce logic and computed history.
+- Migration script that removes `dailyTimestamps` and appends version metadata.
+- Updated `sample-data.json` aligned to the new structure.
+- Test suite covering save, load, and export scenarios.
+
+### Expected Impact
+- 40–50% smaller state object.
+- 70–90% reduction in write operations.
+- Noticeable improvement in UI responsiveness.
+- Backward-compatible data experience.
+
+## Phase 2: IndexedDB Migration (Sprint 2)
+### Objective
+Introduce an asynchronous, scalable persistence layer built on IndexedDB while keeping `localStorage` as a cache.
+
+### Key Actions & Expected Outcomes
+- **Database wrapper:** Implement `DropDB.js` as an IndexedDB helper for async persistence.
+- **Migration:** Seamlessly import existing `localStorage` data into IndexedDB.
+- **Data partitioning:** Cache current-day data in `localStorage`, store historical entries in IndexedDB for faster loads.
+- **Archive store:** Move entries older than 365 days into a dedicated archive table.
+- **Compression:** Integrate LZ-String for exports, reducing export size by 50–60%.
+
+### Deliverables
+- IndexedDB layer covering entries, settings, vision, and archive stores.
+- Automatic migration pathway from the legacy store.
+- Unified API that exposes `getEntries`, `saveEntry`, and `getHistory`.
+- Updated export/import pipeline compatible with IndexedDB.
+
+### Expected Impact
+- 10× capacity increase.
+- Fully non-blocking saves.
+- 3× faster export/import experiences.
+- Foundation for future multi-device synchronization.
+
+## Phase 3: Advanced Enhancements (Future Sprint)
+Optional forward-looking improvements:
+- Automated local backup rotation.
+- Additional compression for large export/import payloads.
+- Cloud synchronization via Supabase or Firebase.
+- Data insights dashboard with storage usage and trend analytics.
+
+## Technical Stack Highlights
+- **Persistent storage:** IndexedDB (with `idb` wrapper) for asynchronous, large-capacity storage.
+- **Compression:** LZ-String as a lightweight, browser-native solution.
+- **Export format:** JSON with optional Base64 compression for interoperability.
+- **Versioning:** `_version` and `_schemaDate` fields to track schema evolution.
+- **Backup:** Local IndexedDB backups employing a rotational policy.
+
+## Testing Strategy
+1. Functional coverage for persistence, export, import, and migration flows.
+2. Stress scenarios simulating 2–3 years of entries (~1 MB of data).
+3. Quota handling tests that intentionally trigger `localStorage` limits.
+4. Cross-device validation to ensure future sync consistency.
+

--- a/docs/sample-data-for-drop.json
+++ b/docs/sample-data-for-drop.json
@@ -1,162 +1,167 @@
 {
-  "wake": "07:00",
-  "rest": "23:00",
-  "run": 12,
-  "strength": true,
-  "skill": ["Wrestling", "Mobility"],
-  "read": true,
-  "write": false,
-  "quadrant": 2,
-  "meditation": true,
-  "energy": 75,
-  "mood": 60,
-  "skillOptions": ["Wrestling", "Volleyball", "Mobility", "Yoga", "Plyometrics"],
-  "visionTheme": "Focus",
-  "visionSleepFocus": "Consistent bedtime",
-  "visionFitnessFocus": "Run 3x week",
-  "visionMindFocus": "Read daily",
-  "visionSpiritFocus": "Meditation practice",
-  "history": [
-    { "date": "2025-09-30", "scores": { "sleep": 85, "fitness": 60, "mind": 100, "spirit": 75 } },
-    { "date": "2025-10-01", "scores": { "sleep": 90, "fitness": 45, "mind": 100, "spirit": 80 } },
-    { "date": "2025-10-02", "scores": { "sleep": 70, "fitness": 70, "mind": 45, "spirit": 50 } },
-    { "date": "2025-10-03", "scores": { "sleep": 60, "fitness": 85, "mind": 100, "spirit": 65 } },
-    { "date": "2025-10-04", "scores": { "sleep": 75, "fitness": 30, "mind": 0, "spirit": 40 } },
-    { "date": "2025-10-05", "scores": { "sleep": 80, "fitness": 65, "mind": 100, "spirit": 75 } },
-    { "date": "2025-10-06", "scores": { "sleep": 85, "fitness": 55, "mind": 100, "spirit": 80 } },
-    { "date": "2025-10-07", "scores": { "sleep": 78, "fitness": 72, "mind": 100, "spirit": 70 } }
-  ],
+  "meta": {
+    "_version": 2,
+    "_schemaDate": "2024-05-01",
+    "lastEntryDate": "2025-10-07",
+    "settings": {
+      "skillOptions": ["Wrestling", "Volleyball", "Mobility", "Yoga", "Plyometrics", "Climbing"],
+      "visionTheme": "Focus",
+      "visionSleepFocus": "Consistent bedtime",
+      "visionFitnessFocus": "Run 3x week",
+      "visionMindFocus": "Read daily",
+      "visionSpiritFocus": "Meditation practice"
+    }
+  },
   "entries": {
-    "2025-09-30": {
-      "wake": "07:10",
-      "rest": "23:20",
-      "run": 10,
-      "strength": true,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 2,
-      "meditation": true,
-      "energy": 70,
-      "mood": 55
-    },
     "2025-10-01": {
-      "wake": "06:50",
-      "rest": "22:40",
+      "wake": "06:45",
+      "rest": "22:45",
       "run": 5,
       "strength": false,
+      "strength_level": 0,
       "skill": ["Mobility"],
-      "read": true,
-      "write": false,
+      "read_level": 2,
+      "write_level": 0,
       "quadrant": 1,
       "meditation": true,
-      "energy": 80,
-      "mood": 70
+      "energy": 70,
+      "mood": 65,
+      "timestamps": {
+        "wake": "2025-10-01T06:45:00.000Z",
+        "run": "2025-10-01T18:15:00.000Z",
+        "meditation": "2025-10-01T21:00:00.000Z"
+      },
+      "scores": {
+        "sleep": 90,
+        "fitness": 55,
+        "mind": 35,
+        "spirit": 80
+      }
     },
     "2025-10-02": {
-      "wake": "08:15",
-      "rest": "00:30",
-      "run": 20,
+      "wake": "07:10",
+      "rest": "23:05",
+      "run": 12,
       "strength": true,
+      "strength_level": 2,
       "skill": ["Wrestling"],
-      "read": false,
-      "write": false,
-      "quadrant": 3,
-      "meditation": false,
-      "energy": 45,
-      "mood": 40
-    },
-    "2025-10-03": {
-      "wake": "07:30",
-      "rest": "23:15",
-      "run": 25,
-      "strength": true,
-      "skill": ["Volleyball", "Yoga"],
-      "read": true,
-      "write": true,
-      "quadrant": 1,
-      "meditation": true,
-      "energy": 85,
-      "mood": 75
-    },
-    "2025-10-04": {
-      "wake": "07:00",
-      "rest": "23:00",
-      "run": 0,
-      "strength": false,
-      "skill": [],
-      "read": false,
-      "write": false,
-      "quadrant": 0,
-      "meditation": false,
-      "energy": 30,
-      "mood": 25
-    },
-    "2025-10-05": {
-      "wake": "06:45",
-      "rest": "22:50",
-      "run": 15,
-      "strength": true,
-      "skill": ["Mobility"],
-      "read": true,
-      "write": false,
-      "quadrant": 1,
-      "meditation": true,
-      "energy": 80,
-      "mood": 65
-    },
-    "2025-10-06": {
-      "wake": "07:20",
-      "rest": "23:10",
-      "run": 10,
-      "strength": false,
-      "skill": ["Wrestling"],
-      "read": true,
-      "write": false,
+      "read_level": 1,
+      "write_level": 0,
       "quadrant": 2,
       "meditation": true,
-      "energy": 72,
-      "mood": 60
+      "energy": 68,
+      "mood": 58,
+      "timestamps": {
+        "wake": "2025-10-02T07:10:00.000Z",
+        "run": "2025-10-02T17:45:00.000Z",
+        "strength": "2025-10-02T18:30:00.000Z"
+      },
+      "scores": {
+        "sleep": 82,
+        "fitness": 80,
+        "mind": 25,
+        "spirit": 78
+      }
     },
-    "2025-10-07": {
-      "wake": "07:05",
-      "rest": "23:05",
+    "2025-10-03": {
+      "wake": "06:30",
+      "rest": "22:20",
+      "run": 0,
+      "strength": false,
+      "strength_level": 0,
+      "skill": [],
+      "read_level": 0,
+      "write_level": 0,
+      "quadrant": 3,
+      "meditation": false,
+      "energy": 40,
+      "mood": 30,
+      "scores": {
+        "sleep": 88,
+        "fitness": 20,
+        "mind": 0,
+        "spirit": 45
+      }
+    },
+    "2025-10-04": {
+      "wake": "07:20",
+      "rest": "23:30",
       "run": 18,
       "strength": true,
+      "strength_level": 3,
+      "skill": ["Volleyball", "Yoga"],
+      "read_level": 2,
+      "write_level": 1,
+      "quadrant": 1,
+      "meditation": true,
+      "energy": 82,
+      "mood": 72,
+      "scores": {
+        "sleep": 80,
+        "fitness": 95,
+        "mind": 70,
+        "spirit": 88
+      }
+    },
+    "2025-10-05": {
+      "wake": "07:05",
+      "rest": "23:10",
+      "run": 9,
+      "strength": true,
+      "strength_level": 2,
+      "skill": ["Climbing"],
+      "read_level": 3,
+      "write_level": 2,
+      "quadrant": 2,
+      "meditation": true,
+      "energy": 76,
+      "mood": 70,
+      "scores": {
+        "sleep": 84,
+        "fitness": 85,
+        "mind": 85,
+        "spirit": 90
+      }
+    },
+    "2025-10-06": {
+      "wake": "06:55",
+      "rest": "22:55",
+      "run": 6,
+      "strength": false,
+      "strength_level": 1,
       "skill": ["Mobility", "Yoga"],
-      "read": true,
-      "write": true,
+      "read_level": 1,
+      "write_level": 1,
+      "quadrant": 4,
+      "meditation": true,
+      "energy": 55,
+      "mood": 45,
+      "scores": {
+        "sleep": 88,
+        "fitness": 60,
+        "mind": 50,
+        "spirit": 68
+      }
+    },
+    "2025-10-07": {
+      "wake": "06:40",
+      "rest": "22:35",
+      "run": 14,
+      "strength": true,
+      "strength_level": 2,
+      "skill": ["Wrestling", "Mobility"],
+      "read_level": 2,
+      "write_level": 2,
       "quadrant": 1,
       "meditation": true,
       "energy": 78,
-      "mood": 68
+      "mood": 74,
+      "scores": {
+        "sleep": 92,
+        "fitness": 90,
+        "mind": 75,
+        "spirit": 92
+      }
     }
-  },
-  "lastEntryDate": "2025-10-07",
-  "dailyTimestamps": {
-    "wake": "2025-10-07",
-    "rest": "2025-10-07",
-    "run": "2025-10-07",
-    "strength": "2025-10-07",
-    "skill": "2025-10-07",
-    "read": "2025-10-07",
-    "write": "2025-10-07",
-    "quadrant": "2025-10-07",
-    "meditation": "2025-10-07",
-    "energy": "2025-10-07",
-    "mood": "2025-10-07"
-  },
-  "actionTimestamps": {
-    "wake": "2025-10-07T09:15:30.123Z",
-    "rest": "2025-10-07T09:15:35.456Z",
-    "run": "2025-10-07T09:16:00.789Z",
-    "strength": "2025-10-07T09:16:10.012Z",
-    "skill": "2025-10-07T09:16:20.345Z",
-    "read": "2025-10-07T09:16:30.678Z",
-    "write": "2025-10-07T09:16:40.901Z",
-    "quadrant": "2025-10-07T09:16:50.234Z",
-    "meditation": "2025-10-07T09:17:00.567Z",
-    "energy": "2025-10-07T09:17:10.890Z",
-    "mood": "2025-10-07T09:17:20.123Z"
   }
 }

--- a/docs/scoring.js
+++ b/docs/scoring.js
@@ -186,7 +186,7 @@ const Scoring = {
    * @returns {number|null} Adjusted score (60-95) or null
    */
   calcTrendScore(domain, rawScore, Store) {
-    const history = Array.isArray(Store.state.history) ? Store.state.history.slice(-7) : [];
+    const history = typeof Store.getHistory === 'function' ? Store.getHistory(7) : [];
 
     if (history.length < 7) {
       return null;

--- a/docs/scoring_old.js
+++ b/docs/scoring_old.js
@@ -177,7 +177,7 @@ const Scoring = {
    * @returns {number|null} Adjusted score (60-95) or null
    */
   calcTrendScore(domain, rawScore, Store) {
-    const history = Array.isArray(Store.state.history) ? Store.state.history.slice(-7) : [];
+    const history = typeof Store.getHistory === 'function' ? Store.getHistory(7) : [];
 
     if (history.length < 7) {
       return null;
@@ -387,7 +387,7 @@ const Scoring = {
    * @returns {number|null} Adjusted score (60-95) or null
    */
   calcTrendScore(domain, rawScore, Store) {
-    const history = Array.isArray(Store.state.history) ? Store.state.history.slice(-7) : [];
+    const history = typeof Store.getHistory === 'function' ? Store.getHistory(7) : [];
     
     // Require at least 7 days of data to establish baseline trend
     if (history.length < 7) {

--- a/docs/store.js
+++ b/docs/store.js
@@ -2,10 +2,22 @@
 // Data persistence and state management for the drop life tracker app
 
 const BASE_SKILL_OPTIONS = ['Wrestling', 'Volleyball', 'Mobility', 'Yoga', 'Plyometrics'];
+const SAVE_DEBOUNCE_MS = 400;
+const SCHEMA_VERSION = 2;
+const SCHEMA_DATE = '2024-05-01';
+const META_SETTINGS_KEYS = [
+  'skillOptions',
+  'visionTheme',
+  'visionSleepFocus',
+  'visionFitnessFocus',
+  'visionMindFocus',
+  'visionSpiritFocus'
+];
 
 const Store = {
   DB_KEY: 'lifeTrackerData',
   state: {},
+  saveTimer: null,
   dailyKeys: ['wake', 'rest', 'run', 'strength', 'strength_level', 'skill', 'read_level', 'write_level', 'quadrant', 'meditation', 'energy', 'mood'],
   defaults: {
     wake: '', rest: '', run: 0, strength: false, strength_level: 0, skill: [],
@@ -14,18 +26,21 @@ const Store = {
     skillOptions: [],
     visionTheme: '', visionSleepFocus: '', visionFitnessFocus: '',
     visionMindFocus: '', visionSpiritFocus: '',
-    history: [],
     lastEntryDate: '',
-    dailyTimestamps: {},
     actionTimestamps: {},
-    entries: {}
+    entries: {},
+    archivedEntries: {},
+    meta: {
+      _version: SCHEMA_VERSION,
+      _schemaDate: SCHEMA_DATE
+    }
   },
 
   init() {
     console.log('🔧 Store.init called');
     const savedData = JSON.parse(localStorage.getItem(this.DB_KEY) || '{}');
     console.log('💾 Loaded from localStorage:', Object.keys(savedData).length, 'keys');
-    
+
     this.state = { ...this.cloneDefaults(), ...savedData };
     console.log('📋 Initial state created with', Object.keys(this.state).length, 'keys');
     console.log('📊 Daily values:', {
@@ -40,40 +55,135 @@ const Store = {
       quadrant: this.state.quadrant
     });
     
-    this.ensureHistory();
-    this.ensureDailyTimestamps();
+    this.applyMigrations(savedData);
+    this.ensureMeta();
     this.ensureEntries();
     this.ensureSkillCollections();
+    this.state.meta.settings = this.collectSettings();
     this.migrateOldMindFields();
-    this.checkForNewDay();
-    this.save();
+    this.hydrateDailyState();
+    this.flushSave();
   },
 
-  ensureHistory() {
-    if (!Array.isArray(this.state.history)) {
-      this.state.history = [];
-    }
-  },
-
-  ensureDailyTimestamps() {
-    if (!this.state.dailyTimestamps || typeof this.state.dailyTimestamps !== 'object' || Array.isArray(this.state.dailyTimestamps)) {
-      this.state.dailyTimestamps = {};
-      return;
+  applyMigrations(savedData) {
+    if (!this.state.meta || typeof this.state.meta !== 'object') {
+      this.state.meta = { ...this.cloneDefaults().meta };
     }
 
-    const sanitized = {};
-    Object.entries(this.state.dailyTimestamps).forEach(([key, value]) => {
-      if (typeof value === 'string' && value) {
-        sanitized[key] = value;
-      }
-    });
-    this.state.dailyTimestamps = sanitized;
+    this.state.meta._version = SCHEMA_VERSION;
+    this.state.meta._schemaDate = SCHEMA_DATE;
+
+    if (this.state.dailyTimestamps) {
+      delete this.state.dailyTimestamps;
+    }
+
+    if (Array.isArray(this.state.history)) {
+      this.migrateHistoryToEntries(this.state.history);
+      delete this.state.history;
+    }
+
+    if (Array.isArray(savedData?.history)) {
+      this.migrateHistoryToEntries(savedData.history);
+    }
   },
 
   ensureEntries() {
     if (!this.state.entries || typeof this.state.entries !== 'object' || Array.isArray(this.state.entries)) {
       this.state.entries = {};
     }
+    if (!this.state.archivedEntries || typeof this.state.archivedEntries !== 'object' || Array.isArray(this.state.archivedEntries)) {
+      this.state.archivedEntries = {};
+    }
+  },
+
+  ensureMeta() {
+    const defaultMeta = this.cloneDefaults().meta;
+    if (!this.state.meta || typeof this.state.meta !== 'object' || Array.isArray(this.state.meta)) {
+      this.state.meta = { ...defaultMeta };
+    }
+    this.state.meta = {
+      ...defaultMeta,
+      ...this.state.meta,
+      _version: SCHEMA_VERSION,
+      _schemaDate: SCHEMA_DATE
+    };
+  },
+
+  hydrateDailyState() {
+    const today = this.getSleepDay();
+    const entry = this.getEntry(today);
+
+    if (entry) {
+      this.applyEntryToState(entry);
+      this.state.actionTimestamps = { ...(entry.timestamps || {}) };
+    } else {
+      this.resetDailyData();
+    }
+
+    this.state.lastEntryDate = today;
+  },
+
+  applyEntryToState(entry) {
+    this.dailyKeys.forEach(key => {
+      if (Object.prototype.hasOwnProperty.call(entry, key)) {
+        const value = entry[key];
+        this.state[key] = Array.isArray(value) ? [...value] : value;
+      } else if (key in this.defaults) {
+        const defaultValue = this.defaults[key];
+        this.state[key] = Array.isArray(defaultValue)
+          ? [...defaultValue]
+          : (defaultValue && typeof defaultValue === 'object')
+            ? JSON.parse(JSON.stringify(defaultValue))
+            : defaultValue;
+      }
+    });
+  },
+
+  migrateHistoryToEntries(history) {
+    if (!Array.isArray(history) || history.length === 0) {
+      return;
+    }
+
+    this.ensureEntries();
+    history.forEach(histEntry => {
+      if (!histEntry || typeof histEntry !== 'object' || !histEntry.date) {
+        return;
+      }
+      const existing = this.state.entries[histEntry.date] || {};
+      this.state.entries[histEntry.date] = {
+        ...existing,
+        scores: { ...(histEntry.scores || {}) }
+      };
+    });
+  },
+
+  getEntry(date) {
+    if (!date) return null;
+    this.ensureEntries();
+    const entry = this.state.entries[date];
+    if (!entry || typeof entry !== 'object') {
+      return null;
+    }
+    return JSON.parse(JSON.stringify(entry));
+  },
+
+  setEntry(date, entry) {
+    if (!date || !entry) return;
+    this.ensureEntries();
+    const sanitized = {};
+    this.dailyKeys.forEach(key => {
+      if (Object.prototype.hasOwnProperty.call(entry, key)) {
+        const value = entry[key];
+        sanitized[key] = Array.isArray(value) ? [...value] : value;
+      }
+    });
+    if (entry.timestamps) {
+      sanitized.timestamps = { ...entry.timestamps };
+    }
+    if (entry.scores) {
+      sanitized.scores = { ...entry.scores };
+    }
+    this.state.entries[date] = sanitized;
   },
 
   ensureSkillCollections() {
@@ -118,6 +228,88 @@ const Store = {
       .map(item => (typeof item === 'string' ? item : String(item ?? '')).trim())
       .filter(Boolean);
     return Array.from(new Set(cleaned)).sort((a, b) => a.localeCompare(b));
+  },
+
+  sanitizeEntriesObject(entries) {
+    if (!entries || typeof entries !== 'object' || Array.isArray(entries)) {
+      return {};
+    }
+    const sanitized = {};
+    Object.entries(entries).forEach(([date, entry]) => {
+      if (typeof date !== 'string' || !entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        return;
+      }
+      const cleaned = {};
+      this.dailyKeys.forEach(key => {
+        if (Object.prototype.hasOwnProperty.call(entry, key)) {
+          const value = entry[key];
+          if (Array.isArray(value)) {
+            cleaned[key] = key === 'skill'
+              ? this.sanitizeStringArray(value)
+              : [...value];
+          } else if (value && typeof value === 'object') {
+            cleaned[key] = JSON.parse(JSON.stringify(value));
+          } else {
+            cleaned[key] = value;
+          }
+        }
+      });
+      if (entry.timestamps && typeof entry.timestamps === 'object' && !Array.isArray(entry.timestamps)) {
+        cleaned.timestamps = { ...entry.timestamps };
+      }
+      if (entry.scores && typeof entry.scores === 'object' && !Array.isArray(entry.scores)) {
+        cleaned.scores = this.normalizeScores(entry.scores);
+      }
+      sanitized[date] = cleaned;
+    });
+    return sanitized;
+  },
+
+  isSanitizedPayload(payload) {
+    return payload && typeof payload === 'object' && !Array.isArray(payload)
+      && typeof payload.entries === 'object'
+      && typeof payload.meta === 'object';
+  },
+
+  extractSettings(settings = {}) {
+    const sanitized = {};
+    META_SETTINGS_KEYS.forEach(key => {
+      if (!Object.prototype.hasOwnProperty.call(settings, key)) {
+        return;
+      }
+      if (key === 'skillOptions') {
+        sanitized[key] = this.sanitizeStringArray(settings[key]);
+      } else {
+        sanitized[key] = typeof settings[key] === 'string' ? settings[key] : String(settings[key] ?? '');
+      }
+    });
+    return sanitized;
+  },
+
+  applySettings(settings = {}) {
+    Object.entries(settings).forEach(([key, value]) => {
+      if (META_SETTINGS_KEYS.includes(key)) {
+        if (Array.isArray(value)) {
+          this.state[key] = [...value];
+        } else {
+          this.state[key] = value;
+        }
+      }
+    });
+    this.ensureSkillCollections();
+  },
+
+  collectSettings() {
+    const settings = {};
+    META_SETTINGS_KEYS.forEach(key => {
+      const value = this.state[key];
+      if (Array.isArray(value)) {
+        settings[key] = [...value];
+      } else if (value !== undefined) {
+        settings[key] = value;
+      }
+    });
+    return settings;
   },
 
   valuesEqual(a, b) {
@@ -216,33 +408,6 @@ const Store = {
     return this.getToday();
   },
 
-  expireStaleDailyData() {
-    this.ensureDailyTimestamps();
-    // Use sleep day for expiring data (00:00-03:59 counts as previous day)
-    const today = this.getSleepDay();
-    let changed = false;
-
-    this.dailyKeys.forEach(key => {
-      const lastLogged = this.state.dailyTimestamps[key];
-      const hasTimestamp = Object.prototype.hasOwnProperty.call(this.state.dailyTimestamps, key);
-      const defaultValue = this.defaults[key];
-      const currentValue = this.state[key];
-      const valueDifferent = !this.valuesEqual(currentValue, defaultValue);
-
-      if (lastLogged !== today && (hasTimestamp || valueDifferent)) {
-        if (key in this.defaults) {
-          this.state[key] = defaultValue;
-        }
-        if (hasTimestamp) {
-          delete this.state.dailyTimestamps[key];
-        }
-        changed = true;
-      }
-    });
-
-    return changed;
-  },
-
   resetDailyData() {
     this.dailyKeys.forEach(key => {
       if (key in this.defaults) {
@@ -256,54 +421,159 @@ const Store = {
         }
       }
     });
-    this.state.dailyTimestamps = {};
+    this.state.actionTimestamps = {};
     this.ensureSkillCollections();
   },
 
   checkForNewDay() {
-    // Use sleep day for checking new day (00:00-03:59 counts as previous day)
     const today = this.getSleepDay();
-    const staleDataCleared = this.expireStaleDailyData();
-    let needsUpdate = false;
 
-    if (this.state.lastEntryDate !== today) {
+    if (this.state.lastEntryDate === today) {
+      return false;
+    }
+
+    const entry = this.getEntry(today);
+    if (entry) {
+      this.applyEntryToState(entry);
+      this.state.actionTimestamps = { ...(entry.timestamps || {}) };
+    } else {
       this.resetDailyData();
-      this.state.lastEntryDate = today;
-      // Clear action timestamps for new day
-      this.state.actionTimestamps = {};
-      needsUpdate = true;
     }
 
-    if (staleDataCleared) {
-      needsUpdate = true;
-    }
+    this.state.lastEntryDate = today;
+    this.scheduleSave();
 
-    if (needsUpdate) {
-      this.save();
-      if (typeof App !== 'undefined') {
-        if (typeof UI !== 'undefined' && typeof UI.syncDailyUI === 'function') {
-          UI.syncDailyUI();
-        }
-        if (typeof App.updateScores === 'function') {
-          App.updateScores();
-        }
+    if (typeof App !== 'undefined') {
+      if (typeof UI !== 'undefined' && typeof UI.syncDailyUI === 'function') {
+        UI.syncDailyUI();
+      }
+      if (typeof App.updateScores === 'function') {
+        App.updateScores();
       }
     }
 
-    return needsUpdate;
+    return true;
   },
 
   save() {
-    localStorage.setItem(this.DB_KEY, JSON.stringify(this.state));
-    if (typeof Backup !== 'undefined' && typeof Backup.handleStoreSave === 'function') {
-      Backup.handleStoreSave();
+    this.scheduleSave();
+  },
+
+  scheduleSave() {
+    if (this.saveTimer) {
+      clearTimeout(this.saveTimer);
     }
+
+    this.saveTimer = setTimeout(() => {
+      this.saveTimer = null;
+      this.persistState();
+    }, SAVE_DEBOUNCE_MS);
+  },
+
+  flushSave() {
+    if (this.saveTimer) {
+      clearTimeout(this.saveTimer);
+      this.saveTimer = null;
+    }
+    this.persistState();
+  },
+
+  persistState() {
+    const payload = this.getPersistedState();
+
+    try {
+      localStorage.setItem(this.DB_KEY, JSON.stringify(payload));
+      if (typeof Backup !== 'undefined' && typeof Backup.handleStoreSave === 'function') {
+        Backup.handleStoreSave();
+      }
+    } catch (error) {
+      if (this.isQuotaError(error)) {
+        const recovered = this.handleQuotaExceeded();
+        if (recovered) {
+          this.persistState();
+          return;
+        }
+        console.error('Quota exceeded and automatic recovery failed:', error);
+        if (typeof UI !== 'undefined' && typeof UI.notify === 'function') {
+          UI.notify('Storage is full. Please export and clear old data.', 5000);
+        }
+      } else {
+        throw error;
+      }
+    }
+  },
+
+  isQuotaError(error) {
+    if (!error) return false;
+    return error.name === 'QuotaExceededError' ||
+      error.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+      error.code === 22 ||
+      error.code === 1014;
+  },
+
+  handleQuotaExceeded() {
+    const pruned = this.archiveOldEntries();
+    if (pruned > 0) {
+      console.warn(`Storage quota exceeded. Archived ${pruned} old entries.`);
+      return true;
+    }
+    return false;
+  },
+
+  archiveOldEntries(limit = 14) {
+    this.ensureEntries();
+    const dates = Object.keys(this.state.entries).sort();
+    if (dates.length === 0) {
+      return 0;
+    }
+
+    const count = Math.min(limit, Math.max(1, Math.floor(dates.length * 0.1)));
+    const toArchive = dates.slice(0, count);
+
+    toArchive.forEach(date => {
+      const entry = this.state.entries[date];
+      if (entry) {
+        this.state.archivedEntries[date] = entry;
+        delete this.state.entries[date];
+      }
+    });
+
+    this.state.meta = {
+      ...this.state.meta,
+      lastArchive: new Date().toISOString(),
+      archivedCount: (this.state.meta?.archivedCount || 0) + toArchive.length
+    };
+
+    return toArchive.length;
+  },
+
+  getPersistedState() {
+    return { ...this.state };
+  },
+
+  getSanitizedExport() {
+    const entries = this.sanitizeEntriesObject(this.state.entries);
+    const archivedEntries = this.sanitizeEntriesObject(this.state.archivedEntries);
+    const meta = {
+      ...this.state.meta,
+      _version: SCHEMA_VERSION,
+      _schemaDate: SCHEMA_DATE,
+      exportedAt: new Date().toISOString(),
+      lastEntryDate: this.state.lastEntryDate || '',
+      settings: this.collectSettings()
+    };
+
+    if (Object.keys(archivedEntries).length > 0) {
+      meta.archivedEntries = archivedEntries;
+    }
+
+    return { meta, entries };
   },
 
   update(key, value) {
     this.checkForNewDay();
     console.log('📝 Store.update called:', key, '=', value);
-    
+
     if (key in this.state) {
       let newValue = value;
       if (key === 'skill' || key === 'skillOptions') {
@@ -313,12 +583,10 @@ const Store = {
       }
       this.state[key] = newValue;
       console.log('✅ State updated:', key, '=', this.state[key]);
-      
+
       if (this.dailyKeys.includes(key)) {
         // Use sleep day for daily tracking (00:00-03:59 counts as previous day)
         this.state.lastEntryDate = this.getSleepDay();
-        this.ensureDailyTimestamps();
-        this.state.dailyTimestamps[key] = this.state.lastEntryDate;
         console.log('📅 Daily key logged for:', this.state.lastEntryDate);
         // Add timestamp when data is logged
         if (!this.state.actionTimestamps) {
@@ -330,7 +598,7 @@ const Store = {
       }
       this.save();
       console.log('💾 State saved to localStorage');
-      
+
       if (!key.startsWith('vision')) {
         console.log('🔄 Triggering score update for key:', key);
         App.updateScores();
@@ -347,7 +615,8 @@ const Store = {
     this.ensureEntries();
     // Use sleep day for saving entries (00:00-03:59 counts as previous day)
     const today = this.getSleepDay();
-    const entry = {};
+    const existing = this.state.entries[today] || {};
+    const entry = { ...existing };
 
     // Save all daily keys to the entry
     this.dailyKeys.forEach(key => {
@@ -358,6 +627,10 @@ const Store = {
     // Save action timestamps for this day
     if (this.state.actionTimestamps) {
       entry.timestamps = { ...this.state.actionTimestamps };
+    }
+
+    if (existing.scores) {
+      entry.scores = { ...existing.scores };
     }
 
     // Only save if there's actual data (not all defaults)
@@ -371,7 +644,9 @@ const Store = {
     });
 
     if (hasData) {
-      this.state.entries[today] = entry;
+      this.setEntry(today, entry);
+    } else if (this.state.entries[today]) {
+      delete this.state.entries[today];
     }
   },
 
@@ -381,28 +656,53 @@ const Store = {
       return false;
     }
 
+    if (this.isSanitizedPayload(payload)) {
+      return this.validateSanitizedPayload(payload);
+    }
+
+    return this.validateLegacyPayload(payload);
+  },
+
+  validateSanitizedPayload(payload) {
+    const { meta, entries } = payload;
+
+    if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+      console.error('❌ Import validation failed: meta must be an object');
+      return false;
+    }
+
+    if (!entries || typeof entries !== 'object' || Array.isArray(entries)) {
+      console.error('❌ Import validation failed: entries must be an object');
+      return false;
+    }
+
+    if (meta.settings && (typeof meta.settings !== 'object' || Array.isArray(meta.settings))) {
+      console.error('❌ Import validation failed: meta.settings must be an object when provided');
+      return false;
+    }
+
+    return true;
+  },
+
+  validateLegacyPayload(payload) {
     const allowedKeys = Object.keys(this.defaults);
-    
-    // Check each key in the payload
+
     for (const key of Object.keys(payload)) {
-      // Skip keys that aren't in defaults (allow extra keys for backwards compatibility)
       if (!allowedKeys.includes(key)) {
         console.warn(`⚠️ Import: Ignoring unknown key "${key}"`);
         continue;
       }
-      
+
       const defaultValue = this.defaults[key];
       const value = payload[key];
 
-      // Allow null/undefined values (they'll be handled by merge)
       if (value === null || value === undefined) {
         console.warn(`⚠️ Import: Key "${key}" is null/undefined, will use default`);
         continue;
       }
 
       const defaultType = typeof defaultValue;
-      
-      // Validate arrays
+
       if (Array.isArray(defaultValue)) {
         if (!Array.isArray(value)) {
           console.error(`❌ Import validation failed: "${key}" should be array, got ${typeof value}`);
@@ -410,8 +710,7 @@ const Store = {
         }
         continue;
       }
-      
-      // Validate booleans
+
       if (defaultType === 'boolean') {
         if (typeof value !== 'boolean') {
           console.error(`❌ Import validation failed: "${key}" should be boolean, got ${typeof value}`);
@@ -419,8 +718,7 @@ const Store = {
         }
         continue;
       }
-      
-      // Validate numbers
+
       if (defaultType === 'number') {
         if (typeof value !== 'number' || !Number.isFinite(value)) {
           console.error(`❌ Import validation failed: "${key}" should be finite number, got ${typeof value}`);
@@ -428,8 +726,7 @@ const Store = {
         }
         continue;
       }
-      
-      // Validate strings
+
       if (defaultType === 'string') {
         if (typeof value !== 'string') {
           console.error(`❌ Import validation failed: "${key}" should be string, got ${typeof value}`);
@@ -437,60 +734,121 @@ const Store = {
         }
         continue;
       }
-      
-      // Validate objects (but be lenient for entries and history)
+
       if (defaultType === 'object') {
         if (!value || typeof value !== 'object' || Array.isArray(value)) {
           console.error(`❌ Import validation failed: "${key}" should be object, got ${typeof value}`);
           return false;
         }
-        // For entries and history, just check it's an object - don't validate internal structure
-        // This allows backwards compatibility with older data formats
-        if (key === 'entries' || key === 'history') {
-          console.log(`✅ Import: "${key}" is valid object (internal structure not validated)`);
+
+        if (key === 'entries') {
+          console.log('✅ Import: entries object detected (legacy format)');
           continue;
         }
-        continue;
       }
     }
-    
-    console.log('✅ Import validation passed');
+
+    console.log('✅ Legacy import validation passed');
     return true;
   },
 
   merge(payload) {
-    this.state = { ...this.state, ...payload };
-    this.ensureHistory();
-    this.ensureDailyTimestamps();
-    this.ensureEntries();
-    this.ensureSkillCollections();
-    this.save();
-    if (typeof App !== 'undefined') {
-      if (typeof UI !== 'undefined' && typeof UI.syncDailyUI === 'function') {
-        UI.syncDailyUI();
-      }
-      if (typeof App.updateScores === 'function') {
-        App.updateScores();
-      }
+    if (this.isSanitizedPayload(payload)) {
+      this.mergeSanitizedPayload(payload);
+      return;
     }
+
+    this.mergeLegacyPayload(payload);
+  },
+
+  mergeSanitizedPayload(payload) {
+    const defaults = this.cloneDefaults();
+    const sanitizedEntries = this.sanitizeEntriesObject(payload.entries);
+    const settings = this.extractSettings(payload.meta?.settings || {});
+    const archivedEntries = this.sanitizeEntriesObject(payload.meta?.archivedEntries || {});
+
+    this.state = {
+      ...defaults,
+      entries: sanitizedEntries,
+      archivedEntries,
+      meta: {
+        ...defaults.meta,
+        ...payload.meta,
+        settings
+      }
+    };
+
+    this.applySettings(settings);
+
+    if (payload.meta?.lastEntryDate) {
+      this.state.lastEntryDate = payload.meta.lastEntryDate;
+      const entry = this.getEntry(payload.meta.lastEntryDate);
+      if (entry) {
+        this.applyEntryToState(entry);
+        this.state.actionTimestamps = { ...(entry.timestamps || {}) };
+      } else {
+        this.hydrateDailyState();
+      }
+    } else {
+      this.hydrateDailyState();
+    }
+
+    this.state.meta.settings = this.collectSettings();
+    this.flushSave();
+    this.notifyStateUpdated();
+  },
+
+  mergeLegacyPayload(payload) {
+    const mergedState = { ...this.state, ...payload };
+
+    if (payload.entries) {
+      mergedState.entries = this.sanitizeEntriesObject(payload.entries);
+    }
+
+    if (payload.archivedEntries) {
+      mergedState.archivedEntries = this.sanitizeEntriesObject(payload.archivedEntries);
+    }
+
+    if (payload.skillOptions) {
+      mergedState.skillOptions = this.sanitizeStringArray(payload.skillOptions);
+    }
+
+    if (payload.skill) {
+      mergedState.skill = this.sanitizeStringArray(payload.skill);
+    }
+
+    delete mergedState.history;
+    delete mergedState.dailyTimestamps;
+
+    mergedState.meta = {
+      ...this.cloneDefaults().meta,
+      ...(mergedState.meta || {})
+    };
+
+    this.state = mergedState;
+    this.ensureEntries();
+    this.ensureMeta();
+    this.ensureSkillCollections();
+    this.state.meta.settings = this.collectSettings();
+    this.hydrateDailyState();
+    this.flushSave();
+    this.notifyStateUpdated();
   },
 
   clearAllData() {
     this.state = this.cloneDefaults();
-    this.ensureHistory();
-    this.ensureDailyTimestamps();
     this.ensureEntries();
+    this.ensureMeta();
     this.ensureSkillCollections();
+    this.state.meta.settings = this.collectSettings();
     delete this.state.currentDate;
-    this.save();
+    this.flushSave();
   },
 
   recordHistory(scores) {
     if (!scores || typeof scores !== 'object') return;
 
-    this.ensureHistory();
-
-    const today = this.getToday();
+    const today = this.getSleepDay();
     const safeScores = ['sleep', 'fitness', 'mind', 'spirit'].reduce((acc, domain) => {
       const value = Number(scores[domain]);
       const safeValue = Number.isFinite(value) ? Math.max(0, Math.min(100, Math.round(value))) : 0;
@@ -502,29 +860,75 @@ const Store = {
     const hasData = Object.values(safeScores).some(score => score > 0);
     if (!hasData) return;
 
-    const history = Array.isArray(this.state.history) ? [...this.state.history] : [];
-    const existingIndex = history.findIndex(entry => entry.date === today);
-    const snapshot = { date: today, scores: safeScores };
-
-    if (existingIndex >= 0) {
-      history[existingIndex] = snapshot;
-    } else {
-      history.push(snapshot);
+    const entry = this.getEntry(today) || {};
+    entry.scores = safeScores;
+    if (!entry.timestamps && this.state.actionTimestamps) {
+      entry.timestamps = { ...this.state.actionTimestamps };
     }
 
-    const MAX_ENTRIES = 14;
-    if (history.length > MAX_ENTRIES) {
-      history.splice(0, history.length - MAX_ENTRIES);
-    }
-
-    this.state.history = history;
+    this.setEntry(today, entry);
     this.state.lastEntryDate = today;
     this.save();
   },
 
+  getHistory(days = 14, options = {}) {
+    const { includeArchived = false } = options;
+    this.ensureEntries();
+
+    const activeEntries = this.state.entries || {};
+    const archivedEntries = includeArchived ? (this.state.archivedEntries || {}) : {};
+    const combined = { ...archivedEntries, ...activeEntries };
+    const dates = Object.keys(combined).sort();
+
+    const limitedDates = typeof days === 'number' && days > 0
+      ? dates.slice(-days)
+      : dates;
+
+    return limitedDates.map(date => {
+      const entry = combined[date] || {};
+      const scores = this.normalizeScores(entry.scores || this.calculateScores(entry));
+      return { date, scores };
+    });
+  },
+
+  calculateScores(entry) {
+    if (typeof Scoring !== 'undefined' && typeof Scoring.calculateDomainScores === 'function') {
+      return Scoring.calculateDomainScores(entry);
+    }
+    return { sleep: 0, fitness: 0, mind: 0, spirit: 0 };
+  },
+
+  normalizeScores(scores = {}) {
+    const domains = ['sleep', 'fitness', 'mind', 'spirit'];
+    return domains.reduce((acc, domain) => {
+      const value = Number(scores[domain]);
+      acc[domain] = Number.isFinite(value) ? Math.max(0, Math.min(100, Math.round(value))) : 0;
+      return acc;
+    }, {});
+  },
+
+  notifyStateUpdated() {
+    if (typeof UI !== 'undefined') {
+      if (typeof UI.syncDailyUI === 'function') {
+        UI.syncDailyUI();
+      }
+      if (typeof UI.setVisionFields === 'function') {
+        UI.setVisionFields(this.state);
+      }
+      if (typeof UI.updatePracticeValues === 'function') {
+        UI.updatePracticeValues();
+      }
+    }
+
+    if (typeof App !== 'undefined' && typeof App.updateScores === 'function') {
+      App.updateScores();
+    }
+  },
+
   handleExport() {
     try {
-      const data = JSON.stringify(this.state, null, 2);
+      const exportData = this.getSanitizedExport();
+      const data = JSON.stringify(exportData, null, 2);
       const blob = new Blob([data], { type: 'application/json' });
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
       const fileName = `drop-life-tracker-${timestamp}.json`;

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -33,20 +33,29 @@ Test data files for import/export functionality testing.
 **Data Structure:**
 ```json
 {
-  "wake": "06:30",
-  "rest": "22:00",
-  "run": 5,
-  "strength": true,
-  "skill": [],
-  "read": true,
-  "write": false,
-  "quadrant": 2,
-  "meditation": true,
-  "visionTheme": "Build healthy habits...",
-  "lastEntryDate": "2024-10-06",
-  "history": [
-    {
-      "date": "2024-09-07",
+  "meta": {
+    "_version": 2,
+    "_schemaDate": "2024-05-01",
+    "lastEntryDate": "2024-10-06",
+    "settings": {
+      "skillOptions": ["Wrestling", "Mobility", "Yoga"],
+      "visionTheme": "Build healthy habits..."
+    }
+  },
+  "entries": {
+    "2024-09-07": {
+      "wake": "06:30",
+      "rest": "22:00",
+      "run": 5,
+      "strength": true,
+      "strength_level": 1,
+      "skill": ["Mobility"],
+      "read_level": 2,
+      "write_level": 1,
+      "quadrant": 2,
+      "meditation": true,
+      "energy": 64,
+      "mood": 58,
       "scores": {
         "sleep": 85,
         "fitness": 75,
@@ -55,7 +64,7 @@ Test data files for import/export functionality testing.
       }
     }
     // ... 29 more entries
-  ]
+  }
 }
 ```
 

--- a/docs/tests/dom.test.js
+++ b/docs/tests/dom.test.js
@@ -246,42 +246,72 @@ QUnit.module('Data Management', function(hooks) {
 
   QUnit.test('clearAllData resets state to defaults', function(assert) {
     const today = new Date().toISOString().slice(0, 10);
-    const payload = this.testHooks.getDefaults();
-    payload.wake = '06:15';
-    payload.run = 8;
-    payload.lastEntryDate = today;
-    payload.dailyTimestamps = { wake: today, run: today };
-    payload.history = [{ date: today, scores: { sleep: 90, fitness: 80, mind: 70, spirit: 60 } }];
+    const payload = {
+      meta: {
+        lastEntryDate: today,
+        settings: {
+          skillOptions: ['Climbing']
+        }
+      },
+      entries: {
+        [today]: {
+          wake: '06:15',
+          rest: '21:45',
+          run: 8,
+          strength: true,
+          skill: ['Mobility'],
+          timestamps: {
+            wake: `${today}T06:15:00.000Z`
+          },
+          scores: { sleep: 90, fitness: 80, mind: 70, spirit: 60 }
+        }
+      }
+    };
 
     this.testHooks.merge(payload);
 
     let state = this.testHooks.getState();
     assert.equal(state.wake, '06:15', 'Wake time imported');
     assert.equal(state.run, 8, 'Run distance imported');
-    assert.ok(Array.isArray(state.history) && state.history.length === 1, 'History imported');
+    assert.deepEqual(state.entries[today].scores, payload.entries[today].scores, 'Scores stored on entry');
+    assert.deepEqual(state.skillOptions, ['Climbing'], 'Skill options imported');
 
     this.testHooks.clearAllData();
     state = this.testHooks.getState();
 
     assert.equal(state.wake, '', 'Wake time reset');
     assert.equal(state.run, 0, 'Run distance reset');
-    assert.deepEqual(state.history, [], 'History cleared');
+    assert.deepEqual(state.entries, {}, 'Entries cleared');
+    assert.deepEqual(state.skillOptions, [], 'Skill options reset');
   });
 
   QUnit.test('validateImport rejects invalid payloads', function(assert) {
-    const payload = this.testHooks.getDefaults();
-    payload.run = 'five';
+    const invalidMeta = { meta: [], entries: {} };
+    assert.notOk(this.testHooks.validateImport(invalidMeta), 'Invalid meta rejected');
 
-    assert.notOk(this.testHooks.validateImport(payload), 'String values for numeric fields are rejected');
+    const invalidEntries = { meta: {}, entries: [] };
+    assert.notOk(this.testHooks.validateImport(invalidEntries), 'Invalid entries rejected');
   });
 
   QUnit.test('validateImport accepts valid payloads and merge applies data', function(assert) {
     const today = new Date().toISOString().slice(0, 10);
-    const payload = this.testHooks.getDefaults();
-    payload.wake = '05:45';
-    payload.strength = true;
-    payload.dailyTimestamps = { wake: today, strength: today };
-    payload.lastEntryDate = today;
+    const payload = {
+      meta: {
+        lastEntryDate: today,
+        settings: {
+          skillOptions: ['Yoga']
+        }
+      },
+      entries: {
+        [today]: {
+          wake: '05:45',
+          rest: '22:15',
+          run: 5,
+          strength: true,
+          skill: ['Yoga']
+        }
+      }
+    };
 
     assert.ok(this.testHooks.validateImport(payload), 'Valid payload passes validation');
 
@@ -289,7 +319,12 @@ QUnit.module('Data Management', function(hooks) {
     const state = this.testHooks.getState();
 
     assert.equal(state.wake, '05:45', 'Wake time updated from import');
+    assert.equal(state.rest, '22:15', 'Rest time imported correctly');
+    assert.equal(state.run, 5, 'Run distance imported correctly');
     assert.strictEqual(state.strength, true, 'Boolean fields import correctly');
+    assert.deepEqual(state.skill, ['Yoga'], 'Skill array imported correctly');
+    assert.deepEqual(state.skillOptions, ['Yoga'], 'Skill options imported correctly');
+    assert.equal(state.lastEntryDate, today, 'Last entry date imported correctly');
   });
 });
 

--- a/docs/tests/sample-data-1month.json
+++ b/docs/tests/sample-data-1month.json
@@ -1,758 +1,227 @@
 {
-  "wake": "07:30",
-  "rest": "23:45",
-  "run": 0,
-  "strength": false,
-  "skill": ["Wrestling"],
-  "read": true,
-  "write": false,
-  "quadrant": 2,
-  "meditation": true,
-  "energy": 65,
-  "mood": 55,
-  "skillOptions": [
-    "Wrestling",
-    "Volleyball",
-    "Mobility",
-    "Yoga",
-    "Plyometrics"
-  ],
-  "visionTheme": "Focus",
-  "visionSleepFocus": "Consistent bedtime",
-  "visionFitnessFocus": "Run 3x week",
-  "visionMindFocus": "Read daily",
-  "visionSpiritFocus": "Meditation practice",
-  "history": [
-    {
-      "date": "2025-09-06",
-      "scores": {
-        "sleep": 85,
-        "fitness": 90,
-        "mind": 100,
-        "spirit": 90
-      }
-    },
-    {
-      "date": "2025-09-07",
-      "scores": {
-        "sleep": 90,
-        "fitness": 70,
-        "mind": 95,
-        "spirit": 85
-      }
-    },
-    {
-      "date": "2025-09-08",
-      "scores": {
-        "sleep": 75,
-        "fitness": 50,
-        "mind": 90,
-        "spirit": 80
-      }
-    },
-    {
-      "date": "2025-09-09",
-      "scores": {
-        "sleep": 60,
-        "fitness": 30,
-        "mind": 50,
-        "spirit": 40
-      }
-    },
-    {
-      "date": "2025-09-10",
-      "scores": {
-        "sleep": 70,
-        "fitness": 95,
-        "mind": 80,
-        "spirit": 90
-      }
-    },
-    {
-      "date": "2025-09-11",
-      "scores": {
-        "sleep": 95,
-        "fitness": 60,
-        "mind": 100,
-        "spirit": 95
-      }
-    },
-    {
-      "date": "2025-09-12",
-      "scores": {
-        "sleep": 80,
-        "fitness": 85,
-        "mind": 90,
-        "spirit": 80
-      }
-    },
-    {
-      "date": "2025-09-13",
-      "scores": {
-        "sleep": 85,
-        "fitness": 70,
-        "mind": 100,
-        "spirit": 85
-      }
-    },
-    {
-      "date": "2025-09-14",
-      "scores": {
-        "sleep": 75,
-        "fitness": 80,
-        "mind": 90,
-        "spirit": 75
-      }
-    },
-    {
-      "date": "2025-09-15",
-      "scores": {
-        "sleep": 85,
-        "fitness": 65,
-        "mind": 100,
-        "spirit": 85
-      }
-    },
-    {
-      "date": "2025-09-16",
-      "scores": {
-        "sleep": 65,
-        "fitness": 35,
-        "mind": 40,
-        "spirit": 30
-      }
-    },
-    {
-      "date": "2025-09-17",
-      "scores": {
-        "sleep": 70,
-        "fitness": 100,
-        "mind": 85,
-        "spirit": 90
-      }
-    },
-    {
-      "date": "2025-09-18",
-      "scores": {
-        "sleep": 90,
-        "fitness": 75,
-        "mind": 100,
-        "spirit": 95
-      }
-    },
-    {
-      "date": "2025-09-19",
-      "scores": {
-        "sleep": 80,
-        "fitness": 75,
-        "mind": 90,
-        "spirit": 80
-      }
-    },
-    {
-      "date": "2025-09-20",
-      "scores": {
-        "sleep": 85,
-        "fitness": 80,
-        "mind": 95,
-        "spirit": 85
-      }
-    },
-    {
-      "date": "2025-09-21",
-      "scores": {
-        "sleep": 75,
-        "fitness": 80,
-        "mind": 90,
-        "spirit": 75
-      }
-    },
-    {
-      "date": "2025-09-22",
-      "scores": {
-        "sleep": 80,
-        "fitness": 65,
-        "mind": 95,
-        "spirit": 80
-      }
-    },
-    {
-      "date": "2025-09-23",
-      "scores": {
-        "sleep": 70,
-        "fitness": 50,
-        "mind": 85,
-        "spirit": 70
-      }
-    },
-    {
-      "date": "2025-09-24",
-      "scores": {
-        "sleep": 70,
-        "fitness": 90,
-        "mind": 85,
-        "spirit": 90
-      }
-    },
-    {
-      "date": "2025-09-25",
-      "scores": {
-        "sleep": 95,
-        "fitness": 60,
-        "mind": 100,
-        "spirit": 95
-      }
-    },
-    {
-      "date": "2025-09-26",
-      "scores": {
-        "sleep": 80,
-        "fitness": 95,
-        "mind": 90,
-        "spirit": 80
-      }
-    },
-    {
-      "date": "2025-09-27",
-      "scores": {
-        "sleep": 85,
-        "fitness": 70,
-        "mind": 95,
-        "spirit": 85
-      }
-    },
-    {
-      "date": "2025-09-28",
-      "scores": {
-        "sleep": 75,
-        "fitness": 75,
-        "mind": 90,
-        "spirit": 75
-      }
-    },
-    {
-      "date": "2025-09-29",
-      "scores": {
-        "sleep": 85,
-        "fitness": 65,
-        "mind": 100,
-        "spirit": 85
-      }
-    },
-    {
-      "date": "2025-09-30",
-      "scores": {
-        "sleep": 85,
-        "fitness": 60,
-        "mind": 100,
-        "spirit": 75
-      }
-    },
-    {
-      "date": "2025-10-01",
-      "scores": {
-        "sleep": 90,
-        "fitness": 45,
-        "mind": 100,
-        "spirit": 80
-      }
-    },
-    {
-      "date": "2025-10-02",
-      "scores": {
-        "sleep": 70,
-        "fitness": 70,
-        "mind": 45,
-        "spirit": 50
-      }
-    },
-    {
-      "date": "2025-10-03",
-      "scores": {
-        "sleep": 60,
-        "fitness": 85,
-        "mind": 100,
-        "spirit": 65
-      }
-    },
-    {
-      "date": "2025-10-04",
-      "scores": {
-        "sleep": 75,
-        "fitness": 30,
-        "mind": 0,
-        "spirit": 40
-      }
-    },
-    {
-      "date": "2025-10-05",
-      "scores": {
-        "sleep": 80,
-        "fitness": 65,
-        "mind": 100,
-        "spirit": 75
-      }
-    },
-    {
-      "date": "2025-10-06",
-      "scores": {
-        "sleep": 85,
-        "fitness": 55,
-        "mind": 100,
-        "spirit": 80
-      }
-    },
-    {
-      "date": "2025-10-07",
-      "scores": {
-        "sleep": 78,
-        "fitness": 72,
-        "mind": 100,
-        "spirit": 70
-      }
-    },
-    {
-      "date": "2025-10-08",
-      "scores": {
-        "sleep": 65,
-        "fitness": 40,
-        "mind": 95,
-        "spirit": 80
-      }
+  "meta": {
+    "_version": 2,
+    "_schemaDate": "2024-05-01",
+    "lastEntryDate": "2025-09-30",
+    "settings": {
+      "skillOptions": ["Wrestling", "Mobility", "Yoga"],
+      "visionTheme": "Alignment",
+      "visionSleepFocus": "Lights out by 23:00",
+      "visionFitnessFocus": "Move daily",
+      "visionMindFocus": "Study design",
+      "visionSpiritFocus": "Journal nightly"
     }
-  ],
+  },
   "entries": {
-    "2025-09-06": {
-      "wake": "07:05",
-      "rest": "23:10",
-      "run": 12,
-      "strength": true,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 2,
-      "meditation": true
-    },
-    "2025-09-07": {
-      "wake": "06:45",
-      "rest": "22:50",
-      "run": 0,
-      "strength": true,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 1,
-      "meditation": true
-    },
-    "2025-09-08": {
-      "wake": "07:15",
-      "rest": "23:25",
-      "run": 0,
-      "strength": false,
-      "skill": [
-        "Mobility"
-      ],
-      "read": true,
-      "write": false,
-      "quadrant": 2,
-      "meditation": true
-    },
-    "2025-09-09": {
-      "wake": "08:00",
-      "rest": "00:00",
-      "run": 5,
-      "strength": false,
-      "skill": [],
-      "read": false,
-      "write": false,
-      "quadrant": 4,
-      "meditation": false
-    },
-    "2025-09-10": {
-      "wake": "07:30",
-      "rest": "23:00",
-      "run": 15,
-      "strength": true,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 2,
-      "meditation": true
-    },
-    "2025-09-11": {
-      "wake": "06:50",
-      "rest": "22:45",
-      "run": 0,
-      "strength": false,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 1,
-      "meditation": true
-    },
-    "2025-09-12": {
-      "wake": "07:00",
-      "rest": "23:05",
-      "run": 10,
-      "strength": true,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 2,
-      "meditation": true
-    },
-    "2025-09-13": {
-      "wake": "07:00",
-      "rest": "23:00",
-      "run": 0,
-      "strength": false,
-      "skill": [
-        "Mobility"
-      ],
-      "read": true,
-      "write": true,
-      "quadrant": 1,
-      "meditation": true
-    },
-    "2025-09-14": {
-      "wake": "07:10",
-      "rest": "23:20",
-      "run": 12,
-      "strength": false,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 2,
-      "meditation": true
-    },
-    "2025-09-15": {
-      "wake": "06:55",
-      "rest": "22:55",
-      "run": 0,
-      "strength": true,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 1,
-      "meditation": true
-    },
-    "2025-09-16": {
-      "wake": "07:45",
-      "rest": "23:45",
-      "run": 0,
-      "strength": false,
-      "skill": [],
-      "read": false,
-      "write": false,
-      "quadrant": 3,
-      "meditation": false
-    },
     "2025-09-17": {
-      "wake": "07:20",
-      "rest": "23:15",
-      "run": 18,
+      "wake": "06:55",
+      "rest": "22:35",
+      "run": 4,
       "strength": true,
-      "skill": [],
-      "read": true,
-      "write": false,
+      "strength_level": 1,
+      "skill": ["Mobility"],
+      "read_level": 1,
+      "write_level": 1,
       "quadrant": 2,
-      "meditation": true
+      "meditation": true,
+      "energy": 68,
+      "mood": 60,
+      "scores": { "sleep": 85, "fitness": 65, "mind": 50, "spirit": 78 }
     },
     "2025-09-18": {
-      "wake": "06:55",
-      "rest": "22:50",
-      "run": 0,
-      "strength": true,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 1,
-      "meditation": true
-    },
-    "2025-09-19": {
       "wake": "07:05",
-      "rest": "23:10",
-      "run": 10,
-      "strength": false,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 2,
-      "meditation": true
-    },
-    "2025-09-20": {
-      "wake": "07:00",
-      "rest": "23:00",
-      "run": 0,
-      "strength": true,
-      "skill": [
-        "Mobility"
-      ],
-      "read": true,
-      "write": false,
-      "quadrant": 1,
-      "meditation": true
-    },
-    "2025-09-21": {
-      "wake": "07:15",
-      "rest": "23:25",
-      "run": 12,
-      "strength": false,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 2,
-      "meditation": true
-    },
-    "2025-09-22": {
-      "wake": "07:05",
-      "rest": "23:10",
-      "run": 0,
-      "strength": true,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 1,
-      "meditation": true
-    },
-    "2025-09-23": {
-      "wake": "07:30",
-      "rest": "23:40",
-      "run": 0,
-      "strength": false,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 2,
-      "meditation": true
-    },
-    "2025-09-24": {
-      "wake": "07:35",
-      "rest": "23:20",
-      "run": 12,
-      "strength": true,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 2,
-      "meditation": true
-    },
-    "2025-09-25": {
-      "wake": "06:50",
-      "rest": "22:40",
-      "run": 0,
-      "strength": false,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 1,
-      "meditation": true
-    },
-    "2025-09-26": {
-      "wake": "07:00",
-      "rest": "23:05",
-      "run": 15,
-      "strength": true,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 2,
-      "meditation": true
-    },
-    "2025-09-27": {
-      "wake": "07:00",
-      "rest": "23:00",
-      "run": 0,
-      "strength": false,
-      "skill": [
-        "Mobility"
-      ],
-      "read": true,
-      "write": false,
-      "quadrant": 1,
-      "meditation": true
-    },
-    "2025-09-28": {
-      "wake": "07:10",
-      "rest": "23:20",
-      "run": 10,
-      "strength": false,
-      "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 2,
-      "meditation": true
-    },
-    "2025-09-29": {
-      "wake": "06:55",
       "rest": "22:55",
       "run": 0,
-      "strength": true,
+      "strength": false,
+      "strength_level": 0,
       "skill": [],
-      "read": true,
-      "write": false,
-      "quadrant": 1,
-      "meditation": true
+      "read_level": 0,
+      "write_level": 0,
+      "quadrant": 3,
+      "meditation": false,
+      "energy": 40,
+      "mood": 35,
+      "scores": { "sleep": 80, "fitness": 20, "mind": 0, "spirit": 42 }
     },
-    "2025-09-30": {
-      "wake": "07:10",
-      "rest": "23:20",
-      "run": 10,
+    "2025-09-19": {
+      "wake": "06:40",
+      "rest": "22:20",
+      "run": 16,
       "strength": true,
-      "skill": [],
-      "read": true,
-      "write": false,
+      "strength_level": 2,
+      "skill": ["Wrestling"],
+      "read_level": 2,
+      "write_level": 0,
+      "quadrant": 1,
+      "meditation": true,
+      "energy": 82,
+      "mood": 74,
+      "scores": { "sleep": 92, "fitness": 90, "mind": 65, "spirit": 90 }
+    },
+    "2025-09-20": {
+      "wake": "07:20",
+      "rest": "23:30",
+      "run": 10,
+      "strength": false,
+      "strength_level": 0,
+      "skill": ["Yoga"],
+      "read_level": 1,
+      "write_level": 1,
       "quadrant": 2,
       "meditation": true,
       "energy": 70,
-      "mood": 55
+      "mood": 68,
+      "scores": { "sleep": 78, "fitness": 70, "mind": 55, "spirit": 82 }
     },
-    "2025-10-01": {
+    "2025-09-21": {
+      "wake": "07:00",
+      "rest": "23:05",
+      "run": 7,
+      "strength": true,
+      "strength_level": 1,
+      "skill": ["Mobility"],
+      "read_level": 1,
+      "write_level": 2,
+      "quadrant": 4,
+      "meditation": true,
+      "energy": 58,
+      "mood": 50,
+      "scores": { "sleep": 86, "fitness": 70, "mind": 70, "spirit": 72 }
+    },
+    "2025-09-22": {
+      "wake": "06:35",
+      "rest": "22:15",
+      "run": 13,
+      "strength": true,
+      "strength_level": 2,
+      "skill": ["Wrestling", "Yoga"],
+      "read_level": 3,
+      "write_level": 1,
+      "quadrant": 1,
+      "meditation": true,
+      "energy": 84,
+      "mood": 76,
+      "scores": { "sleep": 94, "fitness": 88, "mind": 85, "spirit": 92 }
+    },
+    "2025-09-23": {
       "wake": "06:50",
       "rest": "22:40",
       "run": 5,
       "strength": false,
-      "skill": [
-        "Mobility"
-      ],
-      "read": true,
-      "write": false,
-      "quadrant": 1,
-      "meditation": true,
-      "energy": 80,
-      "mood": 70
-    },
-    "2025-10-02": {
-      "wake": "08:15",
-      "rest": "00:30",
-      "run": 20,
-      "strength": true,
-      "skill": [
-        "Wrestling"
-      ],
-      "read": false,
-      "write": false,
-      "quadrant": 3,
+      "strength_level": 0,
+      "skill": ["Mobility"],
+      "read_level": 2,
+      "write_level": 0,
+      "quadrant": 2,
       "meditation": false,
-      "energy": 45,
-      "mood": 40
+      "energy": 62,
+      "mood": 58,
+      "scores": { "sleep": 88, "fitness": 55, "mind": 55, "spirit": 60 }
     },
-    "2025-10-03": {
-      "wake": "07:30",
-      "rest": "23:15",
-      "run": 25,
-      "strength": true,
-      "skill": [
-        "Volleyball",
-        "Yoga"
-      ],
-      "read": true,
-      "write": true,
-      "quadrant": 1,
-      "meditation": true,
-      "energy": 85,
-      "mood": 75
-    },
-    "2025-10-04": {
-      "wake": "07:00",
-      "rest": "23:00",
+    "2025-09-24": {
+      "wake": "07:15",
+      "rest": "23:25",
       "run": 0,
       "strength": false,
+      "strength_level": 0,
       "skill": [],
-      "read": false,
-      "write": false,
-      "quadrant": 0,
+      "read_level": 0,
+      "write_level": 0,
+      "quadrant": 3,
       "meditation": false,
-      "energy": 30,
-      "mood": 25
+      "energy": 38,
+      "mood": 32,
+      "scores": { "sleep": 76, "fitness": 15, "mind": 0, "spirit": 35 }
     },
-    "2025-10-05": {
+    "2025-09-25": {
       "wake": "06:45",
-      "rest": "22:50",
+      "rest": "22:30",
+      "run": 9,
+      "strength": true,
+      "strength_level": 1,
+      "skill": ["Wrestling"],
+      "read_level": 1,
+      "write_level": 1,
+      "quadrant": 2,
+      "meditation": true,
+      "energy": 74,
+      "mood": 66,
+      "scores": { "sleep": 90, "fitness": 75, "mind": 55, "spirit": 80 }
+    },
+    "2025-09-26": {
+      "wake": "06:25",
+      "rest": "22:05",
       "run": 15,
       "strength": true,
-      "skill": [
-        "Mobility"
-      ],
-      "read": true,
-      "write": false,
+      "strength_level": 3,
+      "skill": ["Wrestling", "Yoga"],
+      "read_level": 3,
+      "write_level": 2,
+      "quadrant": 1,
+      "meditation": true,
+      "energy": 88,
+      "mood": 82,
+      "scores": { "sleep": 96, "fitness": 95, "mind": 90, "spirit": 94 }
+    },
+    "2025-09-27": {
+      "wake": "07:25",
+      "rest": "23:35",
+      "run": 4,
+      "strength": false,
+      "strength_level": 0,
+      "skill": ["Mobility"],
+      "read_level": 1,
+      "write_level": 0,
+      "quadrant": 4,
+      "meditation": true,
+      "energy": 55,
+      "mood": 48,
+      "scores": { "sleep": 80, "fitness": 45, "mind": 35, "spirit": 58 }
+    },
+    "2025-09-28": {
+      "wake": "06:30",
+      "rest": "22:25",
+      "run": 11,
+      "strength": true,
+      "strength_level": 2,
+      "skill": ["Wrestling"],
+      "read_level": 2,
+      "write_level": 1,
       "quadrant": 1,
       "meditation": true,
       "energy": 80,
-      "mood": 65
+      "mood": 72,
+      "scores": { "sleep": 92, "fitness": 85, "mind": 70, "spirit": 88 }
     },
-    "2025-10-06": {
-      "wake": "07:20",
-      "rest": "23:10",
-      "run": 10,
+    "2025-09-29": {
+      "wake": "06:40",
+      "rest": "22:45",
+      "run": 7,
       "strength": false,
-      "skill": [
-        "Wrestling"
-      ],
-      "read": true,
-      "write": false,
+      "strength_level": 1,
+      "skill": ["Yoga"],
+      "read_level": 1,
+      "write_level": 1,
       "quadrant": 2,
       "meditation": true,
       "energy": 72,
-      "mood": 60
+      "mood": 64,
+      "scores": { "sleep": 88, "fitness": 65, "mind": 55, "spirit": 78 }
     },
-    "2025-10-07": {
-      "wake": "07:05",
-      "rest": "23:05",
-      "run": 18,
+    "2025-09-30": {
+      "wake": "06:50",
+      "rest": "22:50",
+      "run": 12,
       "strength": true,
-      "skill": [
-        "Mobility",
-        "Yoga"
-      ],
-      "read": true,
-      "write": true,
+      "strength_level": 2,
+      "skill": ["Wrestling", "Mobility"],
+      "read_level": 2,
+      "write_level": 2,
       "quadrant": 1,
       "meditation": true,
-      "energy": 78,
-      "mood": 68
-    },
-    "2025-10-08": {
-      "wake": "07:30",
-      "rest": "23:45",
-      "run": 0,
-      "strength": false,
-      "skill": [
-        "Wrestling"
-      ],
-      "read": true,
-      "write": false,
-      "quadrant": 2,
-      "meditation": true,
-      "energy": 65,
-      "mood": 55
+      "energy": 82,
+      "mood": 76,
+      "scores": { "sleep": 90, "fitness": 88, "mind": 80, "spirit": 90 }
     }
-  },
-  "lastEntryDate": "2025-10-08",
-  "dailyTimestamps": {
-    "wake": "2025-10-08",
-    "rest": "2025-10-08",
-    "run": "2025-10-08",
-    "strength": "2025-10-08",
-    "skill": "2025-10-08",
-    "read": "2025-10-08",
-    "write": "2025-10-08",
-    "quadrant": "2025-10-08",
-    "meditation": "2025-10-08",
-    "energy": "2025-10-08",
-    "mood": "2025-10-08"
-  },
-  "actionTimestamps": {
-    "wake": "2025-10-08T09:30:00.000Z",
-    "rest": "2025-10-08T09:30:05.000Z",
-    "run": "2025-10-08T09:30:10.000Z",
-    "strength": "2025-10-08T09:30:15.000Z",
-    "skill": "2025-10-08T09:30:20.000Z",
-    "read": "2025-10-08T09:30:25.000Z",
-    "write": "2025-10-08T09:30:30.000Z",
-    "quadrant": "2025-10-08T09:30:35.000Z",
-    "meditation": "2025-10-08T09:30:40.000Z",
-    "energy": "2025-10-08T09:30:45.000Z",
-    "mood": "2025-10-08T09:30:50.000Z"
   }
 }

--- a/docs/ui.js
+++ b/docs/ui.js
@@ -126,7 +126,7 @@ const UI = {
 
   renderScores(scores, streaks = {}) {
     const announcements = [];
-    const history = Array.isArray(Store.state.history) ? Store.state.history : [];
+    const history = typeof Store.getHistory === 'function' ? Store.getHistory(30) : [];
 
     // Count days with valid baseline data (must have wake AND rest)
     const entries = Store.state.entries || {};
@@ -836,7 +836,7 @@ const UI = {
   },
 
   computeWeekOverWeekChanges(domainLabels) {
-    const history = Array.isArray(Store.state.history) ? [...Store.state.history] : [];
+    const history = typeof Store.getHistory === 'function' ? Store.getHistory(14, { includeArchived: true }) : [];
     if (history.length === 0) {
       return '';
     }
@@ -1580,34 +1580,6 @@ const UI = {
 
     Store.ensureEntries();
     
-    // Migrate: if entries is empty but we have history, populate entries from history
-    const entries = Store.state.entries || {};
-    const history = Store.state.history || [];
-    if (Object.keys(entries).length === 0 && history.length > 0) {
-      console.log('🔄 Migrating history to entries format...');
-      history.forEach(histEntry => {
-        if (histEntry.date) {
-          // Create a minimal entry from history scores
-          entries[histEntry.date] = {
-            wake: '', 
-            rest: '', 
-            run: 0, 
-            strength: false, 
-            skill: false,
-            read: false, 
-            write: false, 
-            quadrant: 0, 
-            meditation: false
-          };
-        }
-      });
-      Store.state.entries = entries;
-      Store.save();
-      console.log(`✅ Migrated ${history.length} history entries`);
-    }
-
-    console.log('📝 Store entries:', Store.state.entries);
-
     // Render history entries grouped by month and week
     const renderHistory = () => {
       const entries = Store.state.entries || {};


### PR DESCRIPTION
## Summary
- refactor the client store to drop legacy daily timestamp/history fields, add schema metadata, debounce persistence, and expose computed history/export helpers
- update analytics, scoring, and UI layers to consume the new Store.getHistory API and rely on entry data instead of stored history snapshots
- refresh sample data fixtures and documentation to the sanitized {meta, entries} structure used by export/import flows

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68edd82fbd80832398b9140afe97102d